### PR TITLE
Implement core procedural universe modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# universemodel
+# Universe Model
+
+This project provides a small set of TypeScript modules for building a
+procedural universe. A single root seed is expanded into deterministic
+sub-seeds that drive `PropertyGraph` evaluations for individual
+`ProceduralEntity` instances.
+
+## Building
+
+```
+npm install
+npm run build
+```
+
+## Example Usage
+
+```ts
+import { SeedManager } from "./dist/SeedManager";
+import { PropertyGraph, PropertyDefinition } from "./dist/PropertyGraph";
+import { ProceduralEntity } from "./dist/ProceduralEntity";
+import { getNoise01, mapRange01 } from "./dist/ProceduralUtils";
+
+const seedManager = new SeedManager("GenesisAlpha42");
+
+const planetDefs: PropertyDefinition[] = [
+  {
+    id: "radius",
+    compute: (_, seed) => mapRange01(getNoise01(seed, "radius"), 1, 5),
+  },
+  {
+    id: "mass",
+    inputs: ["radius"],
+    compute: (ctx) => ctx.radius ** 3,
+  },
+  {
+    id: "gravity",
+    inputs: ["radius", "mass"],
+    compute: (ctx) => ctx.mass / ctx.radius ** 2,
+  },
+];
+
+const graph = new PropertyGraph(planetDefs);
+const earth = new ProceduralEntity(
+  "Planet-X",
+  ["MilkyWay", "System-4", "Planet-X"],
+  seedManager,
+  graph
+);
+
+console.log(earth.generate());
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "universemodel",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/ProceduralEntity.ts
+++ b/src/ProceduralEntity.ts
@@ -1,0 +1,19 @@
+import { SeedManager } from "./SeedManager";
+import { PropertyGraph } from "./PropertyGraph";
+
+export class ProceduralEntity {
+  constructor(
+    public name: string,
+    public path: string[],
+    public seedManager: SeedManager,
+    public graph: PropertyGraph
+  ) {}
+
+  get fullSeed(): string {
+    return this.seedManager.getSubSeed(this.path);
+  }
+
+  generate(log?: (msg: string) => void): Record<string, any> {
+    return this.graph.evaluate(this.fullSeed, log);
+  }
+}

--- a/src/ProceduralUtils.ts
+++ b/src/ProceduralUtils.ts
@@ -1,0 +1,36 @@
+export function getNoise01(seed: string, label: string): number {
+  const data = `${seed}::${label}`;
+  const hash = fnv1a(data);
+  // convert to float in range [0,1]
+  return Number(BigInt(`0x${hash}`) % 0x100000000n) / 0xffffffff;
+}
+
+export function mapRange01(value: number, min: number, max: number): number {
+  return min + (max - min) * value;
+}
+
+export function mapExp(value: number, base: number, range?: [number, number]): number {
+  const result = Math.pow(base, value);
+  if (range) {
+    const [min, max] = range;
+    return min + (max - min) * result;
+  }
+  return result;
+}
+
+export function resolveDiscrete<T>(value: number, thresholds: [number, T][]): T {
+  for (const [thr, val] of thresholds) {
+    if (value < thr) return val;
+  }
+  return thresholds[thresholds.length - 1][1];
+}
+
+function fnv1a(str: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= BigInt(str.charCodeAt(i));
+    hash = (hash * prime) & 0xffffffffffffffffn;
+  }
+  return hash.toString(16).padStart(16, "0");
+}

--- a/src/PropertyGraph.ts
+++ b/src/PropertyGraph.ts
@@ -1,0 +1,44 @@
+export type PropertyDefinition = {
+  id: string;
+  inputs?: string[];
+  compute: (ctx: Record<string, any>, seed: string) => any;
+};
+
+export class PropertyGraph {
+  constructor(private definitions: PropertyDefinition[]) {}
+
+  evaluate(seed: string, log?: (msg: string) => void): Record<string, any> {
+    const pending = new Map<string, PropertyDefinition>();
+    for (const def of this.definitions) {
+      pending.set(def.id, def);
+    }
+    const context: Record<string, any> = {};
+    let iterations = 0;
+    const maxIterations = this.definitions.length * 2;
+
+    while (pending.size > 0 && iterations < maxIterations) {
+      for (const id of Array.from(pending.keys())) {
+        const def = pending.get(id)!;
+        const deps = def.inputs ?? [];
+        if (deps.every((d) => d in context)) {
+          const ctx = deps.reduce((obj, key) => {
+            obj[key] = context[key];
+            return obj;
+          }, {} as Record<string, any>);
+          context[id] = def.compute(ctx, seed);
+          pending.delete(id);
+          if (log) log(`computed ${id}`);
+        }
+      }
+      iterations++;
+    }
+
+    if (pending.size > 0) {
+      throw new Error(
+        `Unresolved properties: ${Array.from(pending.keys()).join(", ")}`
+      );
+    }
+
+    return context;
+  }
+}

--- a/src/SeedManager.ts
+++ b/src/SeedManager.ts
@@ -1,0 +1,31 @@
+export class SeedManager {
+  private cache = new Map<string, string>();
+
+  constructor(public rootSeed: string) {}
+
+  /**
+   * Creates a deterministic sub-seed for a given path.
+   * The path order matters and will be joined with the root seed
+   * using "::" as a separator before hashing.
+   */
+  getSubSeed(path: string[]): string {
+    const key = path.join("::");
+    if (this.cache.has(key)) {
+      return this.cache.get(key)!;
+    }
+    const data = [...path, this.rootSeed].join("::");
+    const hash = this.hashString(data);
+    this.cache.set(key, hash);
+    return hash;
+  }
+
+  private hashString(value: string): string {
+    let hash = 0xcbf29ce484222325n;
+    const prime = 0x100000001b3n;
+    for (let i = 0; i < value.length; i++) {
+      hash ^= BigInt(value.charCodeAt(i));
+      hash = (hash * prime) & 0xffffffffffffffffn;
+    }
+    return hash.toString(16).padStart(16, "0");
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020"],
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add SeedManager for deterministic seed derivation
- create PropertyGraph evaluation system
- implement ProceduralEntity wrapper
- provide utility helpers for noise and mapping
- add build config and example usage in README

## Testing
- `tsc`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d3a77ad5c832698c7016b2792c957