### PR TITLE
Add browser demo and ES module build

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,8 @@ const mars = new ProceduralEntity(
 
 console.log(mars.generate());
 ```
+
+## HTML Demo
+
+After running `npm run build`, open `demo/index.html` in a browser to see a
+Tailwind-powered page that lists the generated properties for a sample planet.

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Universe Model Demo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-6">
+  <h1 class="text-2xl font-bold mb-4">Universe Model Demo</h1>
+  <div id="output" class="space-y-2"></div>
+
+  <script type="module">
+    import { SeedManager } from '../dist/SeedManager.js';
+    import { PropertyGraph } from '../dist/PropertyGraph.js';
+    import { ProceduralEntity } from '../dist/ProceduralEntity.js';
+    import { createPlanetDefinitions } from '../dist/PlanetDefinitions.js';
+
+    const seedManager = new SeedManager('DemoSeed42');
+    const graph = new PropertyGraph(createPlanetDefinitions());
+    const planet = new ProceduralEntity('Planet-X', ['MilkyWay','System-4','Planet-X'], seedManager, graph);
+
+    const properties = planet.generate();
+    const container = document.getElementById('output');
+
+    for (const [key, value] of Object.entries(properties)) {
+      const row = document.createElement('div');
+      row.className = 'flex justify-between bg-white shadow px-4 py-2 rounded';
+      row.innerHTML = `<span class="font-mono">${key}</span><span>${value}</span>`;
+      container.appendChild(row);
+    }
+  </script>
+</body>
+</html>

--- a/src/PlanetDefinitions.ts
+++ b/src/PlanetDefinitions.ts
@@ -1,5 +1,5 @@
 import { PropertyDefinition } from "./PropertyGraph";
-import { getNoise01, mapRange01, resolveDiscrete } from "./ProceduralUtils";
+import { getNoise01, mapRange01, resolveDiscrete } from "./ProceduralUtils.js";
 
 /** Base physical properties of the planet */
 export function createBasicSubsystem(): PropertyDefinition[] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
     "declaration": true,
     "outDir": "dist",
     "strict": true,


### PR DESCRIPTION
## Summary
- output ES module code compatible with browsers
- update `PlanetDefinitions` import path for ESM
- document the new HTML demo
- add `demo/index.html` that visualizes generated planet data

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dc95b8a488326927d22167db8864f