### PR TITLE
Add property grouping capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ const mars = new ProceduralEntity(
 console.log(mars.generate());
 ```
 
+### Grouped Output
+
+Properties can be organised into groups by adding a `group` field to each
+`PropertyDefinition`. Use `generateGrouped()` on a `ProceduralEntity` to obtain
+the values structured by these groups.
+
+```ts
+const grouped = mars.generateGrouped();
+console.log(grouped.basic.radius); // access values by group and id
+```
+
 ## HTML Demo
 
 After running `npm run build`, open `demo/index.html` in a browser to see a

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,14 +19,20 @@
     const graph = new PropertyGraph(createPlanetDefinitions());
     const planet = new ProceduralEntity('Planet-X', ['MilkyWay','System-4','Planet-X'], seedManager, graph);
 
-    const properties = planet.generate();
+    const groups = planet.generateGrouped();
     const container = document.getElementById('output');
 
-    for (const [key, value] of Object.entries(properties)) {
-      const row = document.createElement('div');
-      row.className = 'flex justify-between bg-purple-600 text-black px-4 py-2 rounded-r-full';
-      row.innerHTML = `<span class="font-mono pr-4">${key}</span><span class="flex-1 text-right">${value}</span>`;
-      container.appendChild(row);
+    for (const [group, props] of Object.entries(groups)) {
+      const header = document.createElement('div');
+      header.className = 'text-xl mt-4 mb-2 underline';
+      header.textContent = group;
+      container.appendChild(header);
+      for (const [key, value] of Object.entries(props)) {
+        const row = document.createElement('div');
+        row.className = 'flex justify-between bg-purple-600 text-black px-4 py-2 rounded-r-full';
+        row.innerHTML = `<span class="font-mono pr-4">${key}</span><span class="flex-1 text-right">${value}</span>`;
+        container.appendChild(row);
+      }
     }
   </script>
 </body>

--- a/src/PlanetDefinitions.ts
+++ b/src/PlanetDefinitions.ts
@@ -6,40 +6,49 @@ export function createBasicSubsystem(): PropertyDefinition[] {
   return [
     {
       id: "radius",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "radius"), 0.5, 3),
     },
     {
       id: "density",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "density"), 0.5, 5),
     },
     {
       id: "mass",
       inputs: ["radius", "density"],
+      group: "basic",
       compute: (ctx) => ctx.radius ** 3 * ctx.density,
     },
     {
       id: "gravity",
       inputs: ["mass", "radius"],
+      group: "basic",
       compute: (ctx) => ctx.mass / ctx.radius ** 2,
     },
     {
       id: "axialTilt",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "tilt"), 0, 45),
     },
     {
       id: "dayLength",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "day"), 8, 40),
     },
     {
       id: "yearLength",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "year"), 200, 800),
     },
     {
       id: "waterCoverage",
+      group: "basic",
       compute: (_, seed) => getNoise01(seed, "water"),
     },
     {
       id: "baseTemperature",
+      group: "basic",
       compute: (_, seed) => mapRange01(getNoise01(seed, "temp"), 150, 350),
     },
   ];
@@ -50,11 +59,13 @@ export function createAtmosphereSubsystem(): PropertyDefinition[] {
   return [
     {
       id: "atmosphereDensity",
+      group: "atmosphere",
       compute: (_, seed) => mapRange01(getNoise01(seed, "atm_density"), 0, 10),
     },
     {
       id: "atmosphereType",
       inputs: ["atmosphereDensity"],
+      group: "atmosphere",
       compute: (ctx, seed) =>
         resolveDiscrete(getNoise01(seed, "atm_type"), [
           [0.1, ctx.atmosphereDensity < 0.1 ? "none" : "thin"],
@@ -67,6 +78,7 @@ export function createAtmosphereSubsystem(): PropertyDefinition[] {
     {
       id: "atmosphereComposition",
       inputs: ["atmosphereType"],
+      group: "atmosphere",
       compute: (ctx, seed) => {
         if (ctx.atmosphereType === "none") return "vacuum";
         return resolveDiscrete(getNoise01(seed, "atm_mix"), [
@@ -85,6 +97,7 @@ export function createGeologySubsystem(): PropertyDefinition[] {
   return [
     {
       id: "crustType",
+      group: "geology",
       compute: (_, seed) =>
         resolveDiscrete(getNoise01(seed, "crust"), [
           [0.5, "rocky"],
@@ -95,6 +108,7 @@ export function createGeologySubsystem(): PropertyDefinition[] {
     },
     {
       id: "coreType",
+      group: "geology",
       compute: (_, seed) =>
         resolveDiscrete(getNoise01(seed, "core"), [
           [0.5, "solid"],
@@ -104,6 +118,7 @@ export function createGeologySubsystem(): PropertyDefinition[] {
     },
     {
       id: "tectonicActivity",
+      group: "geology",
       compute: (_, seed) =>
         resolveDiscrete(getNoise01(seed, "tectonic"), [
           [0.3, "none"],
@@ -114,6 +129,7 @@ export function createGeologySubsystem(): PropertyDefinition[] {
     {
       id: "magneticFieldStrength",
       inputs: ["coreType", "radius"],
+      group: "geology",
       compute: (ctx, seed) => {
         const base = ctx.coreType === "molten" ? 1 : ctx.coreType === "solid" ? 0.5 : 1.5;
         return base * mapRange01(getNoise01(seed, "magfield"), 0.1, 3);
@@ -128,6 +144,7 @@ export function createClimateSubsystem(): PropertyDefinition[] {
     {
       id: "weatherPattern",
       inputs: ["baseTemperature", "waterCoverage"],
+      group: "climate",
       compute: (ctx, seed) => {
         const noise = getNoise01(seed, "weather");
         if (ctx.waterCoverage < 0.2) {
@@ -142,6 +159,7 @@ export function createClimateSubsystem(): PropertyDefinition[] {
     {
       id: "dominantBiome",
       inputs: ["baseTemperature", "waterCoverage"],
+      group: "climate",
       compute: (ctx, seed) => {
         const noise = getNoise01(seed, "biome");
         if (ctx.waterCoverage > 0.6) {

--- a/src/ProceduralEntity.ts
+++ b/src/ProceduralEntity.ts
@@ -16,4 +16,9 @@ export class ProceduralEntity {
   generate(log?: (msg: string) => void): Record<string, any> {
     return this.graph.evaluate(this.fullSeed, log);
   }
+
+  /** Generate grouped property results using PropertyGraph.evaluateGrouped */
+  generateGrouped(log?: (msg: string) => void) {
+    return this.graph.evaluateGrouped(this.fullSeed, log);
+  }
 }

--- a/src/PropertyGraph.ts
+++ b/src/PropertyGraph.ts
@@ -2,7 +2,11 @@ export type PropertyDefinition = {
   id: string;
   inputs?: string[];
   compute: (ctx: Record<string, any>, seed: string) => any;
+  /** Optional group used to organize related properties */
+  group?: string;
 };
+
+export type GroupedProperties = Record<string, Record<string, any>>;
 
 export class PropertyGraph {
   constructor(private definitions: PropertyDefinition[]) {}
@@ -40,5 +44,22 @@ export class PropertyGraph {
     }
 
     return context;
+  }
+
+  /**
+   * Evaluates all properties and groups the resulting values by the
+   * {@link PropertyDefinition.group} field.
+   */
+  evaluateGrouped(seed: string, log?: (msg: string) => void): GroupedProperties {
+    const flat = this.evaluate(seed, log);
+    const grouped: GroupedProperties = {};
+    for (const def of this.definitions) {
+      const group = def.group ?? "default";
+      if (!(group in grouped)) {
+        grouped[group] = {};
+      }
+      grouped[group][def.id] = flat[def.id];
+    }
+    return grouped;
   }
 }


### PR DESCRIPTION
## Summary
- support optional group info on property definitions
- implement `evaluateGrouped` in `PropertyGraph`
- expose `generateGrouped` in `ProceduralEntity`
- categorize planet properties into `basic`, `atmosphere`, `geology`, and `climate`
- update README and demo to show grouped output

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685de42eb0e48326a41e90d5e56ff3fd