### PR TITLE
Add visual subsystem for planetary color properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ console.log(earth.generate());
 ## Extended Planet Properties
 
 The `createPlanetDefinitions` helper combines several subsystems such as
-basic physics, atmosphere, geology and climate. The definitions can be
-extended or replaced as needed to model additional effects.
+basic physics, atmosphere, geology and climate. It also includes
+orbital, hydrology, biosphere and a visual subsystem that outputs values
+useful for rendering. The definitions can be extended or replaced as
+needed to model additional effects.
 
 ```ts
 import { createPlanetDefinitions } from "./dist/PlanetDefinitions";

--- a/src/PlanetDefinitions.ts
+++ b/src/PlanetDefinitions.ts
@@ -386,6 +386,75 @@ export function createBiosphereSubsystem(): PropertyDefinition[] {
 }
 
 /** ------------------------------------------------------------------------
+ * 8. VISUAL SUBSYSTEM - parameters for rendering and appearance
+ * --------------------------------------------------------------------- */
+export function createVisualSubsystem(): PropertyDefinition[] {
+  return [
+    {
+      id: "surfaceHue", // 0-360 hue value
+      inputs: ["dominantBiome"],
+      group: "visual",
+      compute: (ctx, seed) => {
+        const base =
+          ctx.dominantBiome === "ocean"
+            ? 210
+            : ctx.dominantBiome === "swamp"
+            ? 120
+            : ctx.dominantBiome === "tundra"
+            ? 200
+            : ctx.dominantBiome === "glacier"
+            ? 190
+            : ctx.dominantBiome === "desert"
+            ? 40
+            : ctx.dominantBiome === "volcanic"
+            ? 10
+            : ctx.dominantBiome === "forest"
+            ? 110
+            : 90;
+        const variance = mapRange01(getNoise01(seed, "surfaceHue"), -10, 10);
+        let hue = base + variance;
+        if (hue < 0) hue += 360;
+        if (hue > 360) hue -= 360;
+        return hue;
+      },
+    },
+    {
+      id: "atmosphereHue", // 0-360 hue value
+      inputs: ["atmosphereComposition"],
+      group: "visual",
+      compute: (ctx, seed) => {
+        const base =
+          ctx.atmosphereComposition === "nitrogen-oxygen"
+            ? 200
+            : ctx.atmosphereComposition === "carbon-dioxide"
+            ? 0
+            : ctx.atmosphereComposition === "methane"
+            ? 300
+            : 120;
+        const variance = mapRange01(getNoise01(seed, "atmoHue"), -20, 20);
+        let hue = base + variance;
+        if (hue < 0) hue += 360;
+        if (hue > 360) hue -= 360;
+        return hue;
+      },
+    },
+    {
+      id: "waterHue", // 0-360 hue value
+      inputs: ["salinity"],
+      group: "visual",
+      compute: (ctx, seed) => {
+        const base = ctx.salinity > 30 ? 210 : 190;
+        const variance = mapRange01(getNoise01(seed, "waterHue"), -5, 5);
+        let hue = base + variance;
+        if (hue < 0) hue += 360;
+        if (hue > 360) hue -= 360;
+        return hue;
+      },
+    },
+  ];
+}
+
+/** ------------------------------------------------------------------------
  * 8. COMBINED EXPORT
  * --------------------------------------------------------------------- */
 export function createPlanetDefinitions(): PropertyDefinition[] {
@@ -397,5 +466,6 @@ export function createPlanetDefinitions(): PropertyDefinition[] {
     ...createOrbitalSubsystem(),
     ...createHydrologySubsystem(),
     ...createBiosphereSubsystem(),
+    ...createVisualSubsystem(),
   ];
 }


### PR DESCRIPTION
## Summary
- introduce a `visual` subsystem that derives hue values for the planet's surface, atmosphere, and water
- include the new subsystem in `createPlanetDefinitions`
- document the visual subsystem in the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685eeeb01d5c8326b6b14c8763ef1d31