### PR TITLE
Add tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ const grouped = mars.generateGrouped();
 console.log(grouped.basic.radius); // access values by group and id
 ```
 
+### Tracing Property Dependencies
+
+Sometimes it's helpful to see exactly how a value was produced. Each
+`ProceduralEntity` exposes `generateTrace()` which returns the computed value
+for every property along with the inputs used. This can be useful for debugging
+or for building more communicative UI elements.
+
+```ts
+const trace = mars.generateTrace(console.log);
+console.log(trace.mass.inputs); // { radius: 1.5, density: 2 }
+console.log(trace.mass.value);  // result of compute function
+```
+
 ## HTML Demo
 
 After running `npm run build`, open `demo/index.html` in a browser to see a

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,7 +20,9 @@
     const planet = new ProceduralEntity('Planet-X', ['MilkyWay','System-4','Planet-X'], seedManager, graph);
 console.log('Planet Entity:', planet);
     const groups = planet.generateGrouped();
+    const trace = planet.generateTrace();
     const container = document.getElementById('output');
+    const rowMap = new Map();
 
     for (const [group, props] of Object.entries(groups)) {
       const header = document.createElement('div');
@@ -29,8 +31,18 @@ console.log('Planet Entity:', planet);
       container.appendChild(header);
       for (const [key, value] of Object.entries(props)) {
         const row = document.createElement('div');
-        row.className = 'flex justify-between bg-purple-600 text-black px-4 py-2 rounded-r-full';
+        row.className = 'flex justify-between bg-purple-600 text-black px-4 py-2 rounded-r-full cursor-pointer';
         row.innerHTML = `<span class="font-mono pr-4">${key}</span><span class="flex-1 text-right">${value}</span>`;
+        row.addEventListener('click', () => {
+          document.querySelectorAll('.highlight').forEach(el => el.classList.remove('ring-2','ring-yellow-400','highlight'));
+          row.classList.add('ring-2','ring-yellow-400','highlight');
+          const inputs = trace[key]?.inputs || {};
+          Object.keys(inputs).forEach(inp => {
+            const el = rowMap.get(inp);
+            if (el) el.classList.add('ring-2','ring-yellow-400','highlight');
+          });
+        });
+        rowMap.set(key, row);
         container.appendChild(row);
       }
     }

--- a/src/ProceduralEntity.ts
+++ b/src/ProceduralEntity.ts
@@ -19,10 +19,19 @@ export class ProceduralEntity {
 
   /** Generate grouped property results using PropertyGraph.evaluateGrouped */
   generateGrouped(log?: (msg: string) => void) {
-   
+
     if (!this.graph.evaluateGrouped) {
       throw new Error("PropertyGraph does not support grouped evaluation");
     }
     return this.graph.evaluateGrouped(this.fullSeed, log);
+  }
+
+  /** Generate detailed traces for each property using PropertyGraph.evaluateWithTrace */
+  generateTrace(log?: (msg: string) => void) {
+    if (!(this.graph as any).evaluateWithTrace) {
+      throw new Error("PropertyGraph does not support trace evaluation");
+    }
+    // Type assertion because evaluateWithTrace is defined on PropertyGraph
+    return (this.graph as any).evaluateWithTrace(this.fullSeed, log);
   }
 }

--- a/src/PropertyGraph.ts
+++ b/src/PropertyGraph.ts
@@ -8,6 +8,12 @@ export type PropertyDefinition = {
 
 export type GroupedProperties = Record<string, Record<string, any>>;
 
+export type TraceEntry = {
+  value: any;
+  inputs: Record<string, any>;
+};
+export type TraceResult = Record<string, TraceEntry>;
+
 export class PropertyGraph {
   constructor(private definitions: PropertyDefinition[]) {}
 
@@ -61,5 +67,52 @@ export class PropertyGraph {
       grouped[group][def.id] = flat[def.id];
     }
     return grouped;
+  }
+
+  /**
+   * Evaluates all properties and returns detailed trace information for each
+   * value, including the exact inputs used during computation.
+   */
+  evaluateWithTrace(seed: string, log?: (msg: string) => void): TraceResult {
+    const pending = new Map<string, PropertyDefinition>();
+    for (const def of this.definitions) {
+      pending.set(def.id, def);
+    }
+    const context: Record<string, any> = {};
+    const trace: TraceResult = {};
+    let iterations = 0;
+    const maxIterations = this.definitions.length * 2;
+
+    while (pending.size > 0 && iterations < maxIterations) {
+      for (const id of Array.from(pending.keys())) {
+        const def = pending.get(id)!;
+        const deps = def.inputs ?? [];
+        if (deps.every((d) => d in context)) {
+          const ctx = deps.reduce((obj, key) => {
+            obj[key] = context[key];
+            return obj;
+          }, {} as Record<string, any>);
+          const value = def.compute(ctx, seed);
+          context[id] = value;
+          trace[id] = { value, inputs: ctx };
+          pending.delete(id);
+          if (log) {
+            const inputs = Object.entries(ctx)
+              .map(([k, v]) => `${k}: ${v}`)
+              .join(", ");
+            log(`computed ${id} = ${value} using ${inputs}`);
+          }
+        }
+      }
+      iterations++;
+    }
+
+    if (pending.size > 0) {
+      throw new Error(
+        `Unresolved properties: ${Array.from(pending.keys()).join(", ")}`
+      );
+    }
+
+    return trace;
   }
 }


### PR DESCRIPTION
## Summary
- expose `evaluateWithTrace` on `PropertyGraph`
- allow `ProceduralEntity.generateTrace` to surface property dependencies
- highlight property dependencies in the demo via click
- document tracing capability in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ef2eefa2883268dfdcb63078429b1