### PR TITLE
Remove row splitting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,5 @@ For an interactive view that visualises property dependencies, open
 
 `demo/visual.html`. This demo displays each subsystem in a draggable card with
 input ports on the left and output ports on the right. Connections can be
-dragged between ports, double‑clicked to remove and rows can be split into new
-cards by double‑clicking. Each connection also shows a label indicating which
-property values are linked.
+dragged between ports and double‑clicked to remove. Each connection also shows
+a label indicating which property values are linked.

--- a/demo/visual.html
+++ b/demo/visual.html
@@ -109,7 +109,6 @@
 
         row.appendChild(outPort);
 
-        row.addEventListener('dblclick', () => subdivideRow(row, card, key));
 
         allPorts.set(outPort.id, outPort);
         allPorts.set(inPort.id, inPort);
@@ -140,34 +139,6 @@
       card.remove();
     }
 
-    function subdivideRow(row, parentCard, key) {
-      const newCard = document.createElement('div');
-      newCard.className = 'card absolute bg-gray-900 p-4 rounded-lg space-y-2';
-      newCard.style.left = (parseInt(parentCard.style.left || 0) + 220) + 'px';
-      newCard.style.top = parentCard.style.top;
-
-      const header = document.createElement('div');
-      header.className = 'flex justify-between items-center mb-2';
-      const title = document.createElement('span');
-      title.className = 'text-lg underline';
-      title.textContent = key;
-      const close = document.createElement('button');
-      close.textContent = '×';
-      close.className = 'text-red-400';
-      close.addEventListener('click', () => removeCard(newCard));
-      header.appendChild(title);
-      header.appendChild(close);
-      newCard.appendChild(header);
-
-      newCard.appendChild(row);
-      workspace.appendChild(newCard);
-      cards.push(newCard);
-      if (!parentCard.querySelector('[data-id]')) removeCard(parentCard);
-      interact(newCard).draggable(dragOptions);
-
-      connections.forEach(c => { c.line.position(); if (c.updateHandle) c.updateHandle(); });
-
-    }
 
     function addConnection(from, to) {
       const line = new LeaderLine(from, to, {


### PR DESCRIPTION
## Summary
- drop double-click handling that split property rows
- remove now-unused `subdivideRow` function from the demo
- update README to reflect that rows can't be split anymore

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f097d7e5c832688aca035e9beb3d2