### PR TITLE
Improve SaaS style demo UI

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,8 +11,8 @@
     }
   </style>
 </head>
-<body class="bg-black text-white p-6 font-sans">
-  <div class="bg-orange-600 text-black text-3xl font-bold px-6 py-4 rounded-r-full mb-6 w-fit">Universe Model Demo</div>
+<body class="bg-gray-50 text-gray-900 p-8 font-sans">
+  <div class="bg-blue-600 text-white text-3xl font-semibold px-6 py-4 rounded-md shadow mb-8 inline-block">Universe Model Demo</div>
   <div id="output" class="space-y-4"></div>
 
   <script type="module">
@@ -32,7 +32,7 @@ console.log('Planet Entity:', planet);
 
     for (const [group, props] of Object.entries(groups)) {
       const card = document.createElement('div');
-      card.className = 'bg-gray-900 p-4 rounded-lg space-y-2';
+      card.className = 'bg-white p-6 rounded-lg shadow space-y-2';
 
       const header = document.createElement('div');
       header.className = 'text-xl mb-2 underline';
@@ -41,13 +41,13 @@ console.log('Planet Entity:', planet);
 
       for (const [key, value] of Object.entries(props)) {
         const row = document.createElement('div');
-        row.className = 'bg-purple-600 text-black px-4 py-2 rounded cursor-pointer';
+        row.className = 'bg-blue-50 hover:bg-blue-100 text-gray-800 px-4 py-2 rounded cursor-pointer';
 
         const wrapper = document.createElement('div');
         wrapper.className = 'flex items-center justify-between space-x-2';
 
         const inPort = document.createElement('div');
-        inPort.className = 'port bg-red-400 rounded-full';
+        inPort.className = 'port bg-red-300 rounded-full border border-red-400';
 
         const keySpan = document.createElement('span');
         keySpan.className = 'font-mono';
@@ -57,7 +57,7 @@ console.log('Planet Entity:', planet);
         valueSpan.textContent = value;
 
         const outPort = document.createElement('div');
-        outPort.className = 'port bg-blue-400 rounded-full';
+        outPort.className = 'port bg-blue-300 rounded-full border border-blue-400';
 
         wrapper.appendChild(inPort);
         wrapper.appendChild(keySpan);
@@ -70,7 +70,7 @@ console.log('Planet Entity:', planet);
         const def = graph.getDefinition(key);
         const formula = def && def.compute ? def.compute.toString().replace(/\n/g, ' ') : '';
         const info = document.createElement('div');
-        info.className = 'text-xs text-white mt-1 font-mono';
+        info.className = 'text-xs text-gray-500 mt-1 font-mono';
         info.textContent = formula + (inputStr ? ` | ${inputStr}` : '');
         row.appendChild(info);
         row.addEventListener('click', () => {

--- a/demo/visual.html
+++ b/demo/visual.html
@@ -21,14 +21,14 @@
     }
     .bg-grid {
       background-image:
-        linear-gradient(#2d2d2d 1px, transparent 1px),
-        linear-gradient(90deg, #2d2d2d 1px, transparent 1px);
+        linear-gradient(#e5e7eb 1px, transparent 1px),
+        linear-gradient(90deg, #e5e7eb 1px, transparent 1px);
       background-size: 40px 40px;
     }
     .card { width: 200px; }
 
-    .row:nth-child(odd) { background: #334155; }
-    .row:nth-child(even) { background: #1f2937; }
+    .row:nth-child(odd) { background: #eef2ff; }
+    .row:nth-child(even) { background: #e0e7ff; }
 
     .port {
       width: 1rem;
@@ -59,10 +59,10 @@
 
   </style>
 </head>
-<body class="bg-black text-white">
+<body class="bg-gray-50 text-gray-900">
   <div id="toolbar" class="absolute z-10 top-2 left-2 space-x-2">
-    <button id="resetBtn" class="bg-gray-700 px-2 py-1 rounded">Reset view</button>
-    <button id="clearBtn" class="bg-gray-700 px-2 py-1 rounded">Clear connections</button>
+    <button id="resetBtn" class="bg-white border border-gray-300 px-2 py-1 rounded shadow text-sm hover:bg-gray-100">Reset view</button>
+    <button id="clearBtn" class="bg-white border border-gray-300 px-2 py-1 rounded shadow text-sm hover:bg-gray-100">Clear connections</button>
   </div>
   <div id="workspace" class="bg-grid">
     <div id="canvas"></div>
@@ -88,7 +88,7 @@
     let left = 20, top = 20;
     for (const [group, props] of Object.entries(groups)) {
       const card = document.createElement('div');
-      card.className = 'card absolute bg-gray-900 p-4 rounded-lg space-y-2';
+      card.className = 'card absolute bg-white p-4 rounded-lg shadow space-y-2';
       card.style.left = left + 'px';
       card.style.top = top + 'px';
       top += 30;
@@ -102,7 +102,7 @@
       title.textContent = group;
       const close = document.createElement('button');
       close.textContent = '×';
-      close.className = 'text-red-400';
+      close.className = 'text-red-500 hover:text-red-700';
       close.addEventListener('click', () => removeCard(card));
       header.appendChild(title);
       header.appendChild(close);
@@ -134,7 +134,7 @@
         row.dataset.id = key;
 
         const inPort = document.createElement('div');
-        inPort.className = 'port bg-red-400 rounded-full in-port';
+        inPort.className = 'port bg-red-300 rounded-full border border-red-400 in-port';
         inPort.id = `in-${key}`;
 
         inPort.dataset.prop = key;
@@ -148,12 +148,12 @@
         const valueInput = document.createElement('input');
         valueInput.type = 'text';
         valueInput.value = value;
-        valueInput.className = 'value-input bg-gray-700 rounded px-1 text-black w-20';
+        valueInput.className = 'value-input bg-gray-100 border border-gray-300 rounded px-1 text-gray-900 w-20';
         row.appendChild(valueInput);
 
 
         const outPort = document.createElement('div');
-        outPort.className = 'port bg-blue-400 rounded-full out-port';
+        outPort.className = 'port bg-blue-300 rounded-full border border-blue-400 out-port';
         outPort.id = `out-${key}`;
         outPort.dataset.prop = key;
 


### PR DESCRIPTION
## Summary
- refresh the demo pages with a lighter SaaS-style theme
- adjust port and card colours
- tweak button and input styling in the visual demo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f27ed5f8083268eef121afd057d29