### PR TITLE
Constrain card layout and move info to tooltips

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -32,7 +32,7 @@ console.log('Planet Entity:', planet);
 
     for (const [group, props] of Object.entries(groups)) {
       const card = document.createElement('div');
-      card.className = 'bg-white p-6 rounded-lg shadow space-y-2';
+      card.className = 'bg-white p-6 rounded-lg shadow space-y-2 w-72';
 
       const header = document.createElement('div');
       header.className = 'text-xl mb-2 underline';
@@ -41,19 +41,20 @@ console.log('Planet Entity:', planet);
 
       for (const [key, value] of Object.entries(props)) {
         const row = document.createElement('div');
-        row.className = 'bg-blue-50 hover:bg-blue-100 text-gray-800 px-4 py-2 rounded cursor-pointer';
+        row.className = 'bg-blue-50 hover:bg-blue-100 text-gray-800 px-4 py-2 rounded cursor-pointer overflow-hidden';
 
         const wrapper = document.createElement('div');
-        wrapper.className = 'flex items-center justify-between space-x-2';
+        wrapper.className = 'flex items-center justify-between space-x-2 w-full';
 
         const inPort = document.createElement('div');
         inPort.className = 'port bg-red-300 rounded-full border border-red-400';
 
         const keySpan = document.createElement('span');
-        keySpan.className = 'font-mono';
+        keySpan.className = 'font-mono truncate flex-1';
         keySpan.textContent = key + ':';
 
         const valueSpan = document.createElement('span');
+        valueSpan.className = 'truncate';
         valueSpan.textContent = value;
 
         const outPort = document.createElement('div');
@@ -69,10 +70,7 @@ console.log('Planet Entity:', planet);
         const inputStr = Object.entries(inputs).map(([k,v]) => `${k}: ${v}`).join(', ');
         const def = graph.getDefinition(key);
         const formula = def && def.compute ? def.compute.toString().replace(/\n/g, ' ') : '';
-        const info = document.createElement('div');
-        info.className = 'text-xs text-gray-500 mt-1 font-mono';
-        info.textContent = formula + (inputStr ? ` | ${inputStr}` : '');
-        row.appendChild(info);
+        row.title = formula + (inputStr ? ` | ${inputStr}` : '');
         row.addEventListener('click', () => {
           document.querySelectorAll('.highlight').forEach(el => el.classList.remove('ring-2','ring-yellow-400','highlight'));
           row.classList.add('ring-2','ring-yellow-400','highlight');

--- a/demo/visual.html
+++ b/demo/visual.html
@@ -98,6 +98,7 @@
     const planet = new ProceduralEntity('Planet-X', ['MilkyWay','System-4','Planet-X'], seedManager, graph);
 
     const groups = planet.generateGrouped();
+    const trace = planet.generateTrace();
     const workspace = document.getElementById('workspace');
     const canvas = document.getElementById('canvas');
 
@@ -188,7 +189,7 @@
 
     for (const [key, value] of Object.entries(props)) {
       const row = document.createElement('div');
-      row.className = 'row flex items-center text-sm mb-1 space-x-1 px-1';
+      row.className = 'row flex items-center text-sm mb-1 space-x-1 px-1 overflow-hidden';
       row.dataset.id = key;
 
       const inPort = document.createElement('div');
@@ -198,6 +199,7 @@
       row.appendChild(inPort);
 
       const label = document.createElement('span');
+      label.className = 'truncate flex-1';
       label.textContent = key + ':';
       row.appendChild(label);
 
@@ -213,6 +215,12 @@
       outPort.dataset.prop = key;
 
       row.appendChild(outPort);
+
+      const inputs = trace[key]?.inputs || {};
+      const inputStr = Object.entries(inputs).map(([k, v]) => `${k}: ${v}`).join(', ');
+      const def = graph.getDefinition(key);
+      const formula = def && def.compute ? def.compute.toString().replace(/\n/g, ' ') : '';
+      row.title = formula + (inputStr ? ` | ${inputStr}` : '');
 
       allPorts.set(outPort.id, outPort);
       allPorts.set(inPort.id, inPort);


### PR DESCRIPTION
## Summary
- keep property text inside demo cards
- show property formulas and inputs as tooltips

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fbcc3f9188326ad582598aa995e80