### PR TITLE
Implement port highlighting and drag feedback

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -6,13 +6,13 @@ implemented.
 
 ## Card Interaction Improvements
 
-- **Drag and Drop Enhancements**: allow card dragging while preserving
+- [x] **Drag and Drop Enhancements**: allow card dragging while preserving
   connections. Provide visual feedback when a card is being moved.
-- **Connection Highlighting**: highlight compatible input/output ports when a
+- [x] **Connection Highlighting**: highlight compatible input/output ports when a
   connection is being dragged to streamline wire creation.
-- **Multiple Selection**: support selecting multiple cards to move them as a
+- [x] **Multiple Selection**: support selecting multiple cards to move them as a
   group.
-- **Context Menu**: add a right‑click context menu for quick actions such as
+- [ ] **Context Menu**: add a right‑click context menu for quick actions such as
   deleting a card or clearing its connections.
 
 ## Connector and Wire Handling

--- a/demo/visual.html
+++ b/demo/visual.html
@@ -78,6 +78,21 @@
       white-space: nowrap;
     }
 
+    /* Visual hint when dragging cards */
+    .dragging {
+      box-shadow: 0 0 0 4px #60a5fa;
+    }
+
+    /* Highlight potential drop targets when wiring */
+    .port-target {
+      outline: 2px dashed #94a3b8;
+    }
+
+    /* Selected cards */
+    .selected {
+      outline: 2px solid #10b981;
+    }
+
   </style>
 </head>
 <body class="bg-gray-50 text-gray-900">
@@ -129,6 +144,30 @@
 
     const connections = [];
 
+    const selectedCards = new Set();
+
+    function clearSelection() {
+      selectedCards.forEach(c => c.classList.remove('selected'));
+      selectedCards.clear();
+    }
+
+    function toggleSelection(card) {
+      if (selectedCards.has(card)) {
+        card.classList.remove('selected');
+        selectedCards.delete(card);
+      } else {
+        card.classList.add('selected');
+        selectedCards.add(card);
+      }
+    }
+
+    function selectSingle(card) {
+      if (selectedCards.size === 1 && selectedCards.has(card)) return;
+      clearSelection();
+      card.classList.add('selected');
+      selectedCards.add(card);
+    }
+
     function removeConnection(conn) {
       conn.line.remove();
 
@@ -175,6 +214,14 @@
       closeBtn.addEventListener('click', () => removeCard(card));
       header.appendChild(closeBtn);
     }
+
+    header.addEventListener('mousedown', e => {
+      if (e.shiftKey) {
+        toggleSelection(card);
+      } else {
+        selectSingle(card);
+      }
+    });
 
     const body = document.createElement('div');
     body.className = 'window-body space-y-1';
@@ -361,6 +408,7 @@
       listeners: {
         start(event) {
           event.target.classList.add('port-hover');
+          document.querySelectorAll('.in-port').forEach(p => p.classList.add('port-target'));
           tempLine = new LeaderLine(
             event.target,
             LeaderLine.pointAnchor({ x: event.clientX, y: event.clientY }),
@@ -381,6 +429,7 @@
         },
         end(event) {
           event.target.classList.remove('port-hover');
+          document.querySelectorAll('.in-port').forEach(p => p.classList.remove('port-target'));
           if (tempLine) {
             tempLine.remove();
             tempLine = null;
@@ -411,18 +460,26 @@
     const dragOptions = {
 
       listeners: {
+        start(event) {
+          if (!selectedCards.has(event.target)) selectSingle(event.target);
+          selectedCards.forEach(c => c.classList.add('dragging'));
+        },
         move(event) {
-          const target = event.target;
-          let x = (parseFloat(target.dataset.x) || 0) + event.dx;
-          let y = (parseFloat(target.dataset.y) || 0) + event.dy;
-          x = snapCoord(x);
-          y = snapCoord(y);
-          target.style.transform = `translate(${x}px, ${y}px)`;
-          target.dataset.x = x;
-          target.dataset.y = y;
+          selectedCards.forEach(card => {
+            let x = (parseFloat(card.dataset.x) || 0) + event.dx;
+            let y = (parseFloat(card.dataset.y) || 0) + event.dy;
+            x = snapCoord(x);
+            y = snapCoord(y);
+            card.style.transform = `translate(${x}px, ${y}px)`;
+            card.dataset.x = x;
+            card.dataset.y = y;
+          });
 
           connections.forEach(c => { c.line.position(); if (c.updatePositions) c.updatePositions(); });
 
+        },
+        end(event) {
+          selectedCards.forEach(c => c.classList.remove('dragging'));
         }
       }
     };


### PR DESCRIPTION
## Summary
- add CSS classes for dragging cards and port highlighting
- highlight input ports when dragging wires
- show dragging style during card drag
- support selecting multiple cards to move them together
- check off corresponding tasks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68600bd5958883269cc8645fa7276e1b