### PR TITLE
Add context menu to cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,5 @@ input ports on the left and output ports on the right. Connections can be
 dragged between ports and removed by double‑clicking the connection label. Each
 connection also shows a label indicating which property values are linked. You
 can double‑click on a connection itself to add hidden anchor points that shape
-the line without altering its curve.
+the line without altering its curve. Right‑click a card to open a small context
+menu with options to remove the card or clear all of its connections.

--- a/TASKS.md
+++ b/TASKS.md
@@ -12,7 +12,7 @@ implemented.
   connection is being dragged to streamline wire creation.
 - [x] **Multiple Selection**: support selecting multiple cards to move them as a
   group.
-- [ ] **Context Menu**: add a right‑click context menu for quick actions such as
+- [x] **Context Menu**: add a right‑click context menu for quick actions such as
   deleting a card or clearing its connections.
 
 ## Connector and Wire Handling
@@ -26,6 +26,8 @@ implemented.
   input field to keep layouts tidy.
 - **Connection Validation**: prevent invalid connections, such as linking an
   output port to itself or creating circular dependencies.
+- **Connection Obstruction**: ensure lines never pass above cards and allow
+  users to insert fixed anchor points along a path for manual rerouting.
 
 ## Dynamic Calculation Tree
 

--- a/demo/visual.html
+++ b/demo/visual.html
@@ -94,6 +94,11 @@
       outline: 2px solid #10b981;
     }
 
+    /* Simple context menu */
+    #contextMenu {
+      min-width: 8rem;
+    }
+
 
   </style>
 </head>
@@ -108,6 +113,7 @@
   <div id="workspace" class="bg-grid">
     <div id="canvas"></div>
   </div>
+  <div id="contextMenu" class="absolute bg-white border border-gray-300 rounded shadow text-sm hidden z-20"></div>
 
   <script type="module">
     import { SeedManager } from '../dist/SeedManager.js';
@@ -147,6 +153,31 @@
     const connections = [];
 
     const selectedCards = new Set();
+
+    const contextMenu = document.getElementById('contextMenu');
+
+    function hideContextMenu() {
+      contextMenu.classList.add('hidden');
+    }
+
+    function showContextMenu(e, items) {
+      contextMenu.innerHTML = '';
+      items.forEach(item => {
+        const div = document.createElement('div');
+        div.textContent = item.label;
+        div.className = 'px-2 py-1 hover:bg-gray-100 cursor-pointer';
+        div.addEventListener('click', () => { item.action(); hideContextMenu(); });
+        contextMenu.appendChild(div);
+      });
+      contextMenu.style.left = e.clientX + 'px';
+      contextMenu.style.top = e.clientY + 'px';
+      contextMenu.classList.remove('hidden');
+    }
+
+    window.addEventListener('click', hideContextMenu);
+    window.addEventListener('contextmenu', e => {
+      if (!contextMenu.contains(e.target)) hideContextMenu();
+    });
 
     function clearSelection() {
       selectedCards.forEach(c => c.classList.remove('selected'));
@@ -223,6 +254,21 @@
       } else {
         selectSingle(card);
       }
+    });
+
+    card.addEventListener('contextmenu', e => {
+      e.preventDefault();
+      selectSingle(card);
+      showContextMenu(e, [
+        { label: 'Delete card', action: () => removeCard(card) },
+        { label: 'Clear connections', action: () => {
+            card.querySelectorAll('.port').forEach(p => {
+              connections.slice().forEach(c => {
+                if (c.from === p || c.to === p) removeConnection(c);
+              });
+            });
+          } }
+      ]);
     });
 
     const body = document.createElement('div');


### PR DESCRIPTION
## Summary
- implement right-click context menu for visual demo cards
- document context menu in README
- tick off the task for context menu and add a new obstruction task

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68601a8ef0c483269731e361e0d731b8