### PR TITLE
Implement reset option

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -213,6 +213,7 @@ window.addEventListener('keydown', e => {
   if (e.code === 'ArrowDown' || e.code === 'KeyS') userInput.down = true;
   if (e.code === 'ArrowLeft' || e.code === 'KeyA') userInput.left = true;
   if (e.code === 'ArrowRight' || e.code === 'KeyD') userInput.right = true;
+  if (e.code === 'KeyR') resetGame();
 });
 window.addEventListener('keyup', e => {
   if (e.code === 'ArrowUp' || e.code === 'KeyW') userInput.up = false;
@@ -269,6 +270,17 @@ function resetKickoff() {
   ball.owner = teamHeim[4]; // oder nach Zufall/Regel
   ball.isLoose = false;
   playWhistle();
+}
+
+function resetGame() {
+  scoreHome = 0;
+  scoreAway = 0;
+  matchTime = 0;
+  halftime = 1;
+  yellowCards = [];
+  redCards = [];
+  resetKickoff();
+  updateScoreboard();
 }
 
 // --- Ball auf Spielfeld halten


### PR DESCRIPTION
## Summary
- allow pressing `R` to reset match state
- add resetGame helper resetting score and timer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68678fd900288326a6cc2e882c6bfdfe