### PR TITLE
Add basic injury mechanic

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -419,7 +419,7 @@ function maybeSubstitute(team, bench) {
   if (!bench.length) return;
   for (let i = 0; i < team.length; i++) {
     const p = team[i];
-    if ((p.stamina ?? 1) < 0.3) {
+    if ((p.stamina ?? 1) < 0.3 || p.injured) {
       substitute(team, bench, i);
       break;
     }
@@ -478,6 +478,7 @@ function gameLoop(timestamp) {
     }
   }
   const allPlayers = [...teamHeim, ...teamGast];
+  allPlayers.forEach(p => p.updateInjury(delta));
 
   // 1. Wahrnehmung (inkl. FOV/Kopf/Memory)
   allPlayers.forEach(p => {

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -79,6 +79,10 @@ export class Player {
     this.bt = createPlayerBT();
     this.controlledByUser = false;
 
+    // Verletzungen
+    this.injured = false;
+    this.injuryRecovery = 0; // Sekunden bis zur Genesung
+
 
     // --- Decision-Timing (Awareness-Skill steuert Intervall) ---
     this.lastDecision = 0;
@@ -204,7 +208,8 @@ export class Player {
     const dy = this.targetY - this.y;
     const dist = Math.hypot(dx, dy);
     if (dist > 1) {
-      const speed = (this.derived.topSpeed ?? 2) * (this.stamina ?? 1) * (this.pressing ?? 1);
+      const injuryMod = this.injured ? 0.4 : 1;
+      const speed = (this.derived.topSpeed ?? 2) * (this.stamina ?? 1) * (this.pressing ?? 1) * injuryMod;
       const step = Math.min(speed, dist);
       this.x += (dx / dist) * step;
       this.y += (dy / dist) * step;
@@ -289,6 +294,15 @@ export class Player {
       }
       return true;
     });
+  }
+
+  updateInjury(delta) {
+    if (this.injured) {
+      this.injuryRecovery -= delta;
+      if (this.injuryRecovery <= 0) {
+        this.injured = false;
+      }
+    }
   }
 
   toString() {

--- a/demo/soccer/referee.js
+++ b/demo/soccer/referee.js
@@ -1,3 +1,5 @@
+import { logComment } from './commentary.js';
+
 export class Referee {
   constructor(onCardCallback) {
     this.onCard = onCardCallback;
@@ -23,5 +25,10 @@ export class Referee {
     const chance = Math.random();
     const card = chance > 0.8 ? "red" : "yellow";
     if (this.onCard) this.onCard(player, card);
+    if (Math.random() < 0.3) {
+      victim.injured = true;
+      victim.injuryRecovery = 30;
+      logComment(`${victim.role} verletzt sich!`);
+    }
   }
 }

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -75,6 +75,13 @@ export function drawPlayers(ctx, players, { showFOV = false, showRunDir = false,
       ctx.fillRect(p.x - p.radius, p.y - p.radius - 6, p.radius * 2 * p.stamina, 3);
     }
 
+    if (p.injured) {
+      ctx.fillStyle = "red";
+      ctx.font = "bold 14px sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText("✚", p.x, p.y - p.radius - 12);
+    }
+
     // Optionally: show number or role
     ctx.font = "bold 12px sans-serif";
     ctx.fillStyle = "#000";


### PR DESCRIPTION
## Summary
- implement injury status for players
- let injured players move slower and recover over time
- show injury marker above affected players
- random chance to injure fouled players
- substitute injured players automatically

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867bf4bacc483269a39696d5333bf30