### PR TITLE
Expand soccer game features from AGENTS2 tasks

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -49,6 +49,9 @@ let shotCharging = false;
 let prevPass = false;
 let prevTackle = false;
 
+let goalFlashTimer = 0;
+let goalFlashSide = null;
+
 let lastBallOwnerTeam = null;
 
 const POIS = [
@@ -480,12 +483,16 @@ function checkGoal(ball) {
     scoreAway++;
     playGoal();
     logComment('Tor für Auswärtsteam!');
+    goalFlashSide = 'left';
+    goalFlashTimer = 1;
     resetKickoff();
   }
   if (ball.x > 1035 && ball.y > 290 && ball.y < 390) {
     scoreHome++;
     playGoal();
     logComment('Tor für Heimteam!');
+    goalFlashSide = 'right';
+    goalFlashTimer = 1;
     resetKickoff();
   }
 }
@@ -783,7 +790,7 @@ function gameLoop(timestamp) {
   }
 
   // 7. RENDER
-  drawField(ctx, canvas.width, canvas.height);
+  drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
   drawZones(ctx, allPlayers);
   drawPasses(ctx, allPlayers, ball);
   drawPassIndicator(ctx, passIndicator);
@@ -797,6 +804,10 @@ function gameLoop(timestamp) {
   // 8. Score/Goal Check/Timer
   checkGoal(ball);
   updateScoreboard();
+  if (goalFlashTimer > 0) {
+    goalFlashTimer -= delta;
+    if (goalFlashTimer < 0) goalFlashTimer = 0;
+  }
   if (currentState === GameState.RUNNING && matchTime - lastFormationSwitch > 30) {
     selectedFormationIndex = (selectedFormationIndex + 1) % formations.length;
     setFormation(selectedFormationIndex);

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -83,6 +83,9 @@ export class Player {
     this.injured = false;
     this.injuryRecovery = 0; // Sekunden bis zur Genesung
 
+    // Kurzer Highlight-Effekt nach Fouls
+    this.highlightTimer = 0;
+  
     // Tackling/Sliding
     this.tackleCooldown = 0;
     this.sliding = false;
@@ -328,6 +331,10 @@ export class Player {
       if (this.injuryRecovery <= 0) {
         this.injured = false;
       }
+    }
+    if (this.highlightTimer > 0) {
+      this.highlightTimer -= delta;
+      if (this.highlightTimer < 0) this.highlightTimer = 0;
     }
   }
 

--- a/demo/soccer/referee.js
+++ b/demo/soccer/referee.js
@@ -30,5 +30,6 @@ export class Referee {
       victim.injuryRecovery = 30;
       logComment(`${victim.role} verletzt sich!`);
     }
+    victim.highlightTimer = 1;
   }
 }

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -1,5 +1,5 @@
 // render.js
-export function drawField(ctx, width, height) {
+export function drawField(ctx, width, height, flashTimer = 0, flashSide = null) {
     ctx.strokeStyle = 'white';
     ctx.lineWidth = 2;
     ctx.clearRect(0, 0, width, height);
@@ -9,6 +9,16 @@ export function drawField(ctx, width, height) {
     ctx.fillStyle = 'white';
     ctx.fillRect(0, height/2-50, 10, 100); // left goal
     ctx.fillRect(width-10, height/2-50, 10, 100); // right goal
+    if (flashTimer > 0 && flashSide) {
+        ctx.save();
+        ctx.fillStyle = `rgba(255,255,0,${flashTimer})`;
+        if (flashSide === 'left') {
+            ctx.fillRect(0, height/2-60, 15, 120);
+        } else if (flashSide === 'right') {
+            ctx.fillRect(width-15, height/2-60, 15, 120);
+        }
+        ctx.restore();
+    }
 }
 export function drawPlayers(ctx, players, { showFOV = false, showRunDir = false, showHeadDir = false } = {}) {
   players.forEach(p => {
@@ -75,6 +85,14 @@ export function drawPlayers(ctx, players, { showFOV = false, showRunDir = false,
       ctx.fillRect(p.x - p.radius, p.y - p.radius - 6, p.radius * 2 * p.stamina, 3);
     }
 
+    if (p.highlightTimer > 0) {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.radius + 6, 0, Math.PI * 2);
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = `rgba(255,0,0,${Math.min(1, p.highlightTimer)})`;
+      ctx.stroke();
+    }
+
     if (p.injured) {
       ctx.fillStyle = "red";
       ctx.font = "bold 14px sans-serif";
@@ -122,6 +140,13 @@ export function drawPasses(ctx, allPlayers, ball) {
 }
 
 export function drawBall(ctx, ball) {
+    if (ball.isLoose) {
+        ctx.beginPath();
+        ctx.arc(ball.x, ball.y, ball.radius + 5, 0, Math.PI * 2);
+        ctx.strokeStyle = 'orange';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+    }
     ctx.beginPath();
     ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI*2);
     ctx.fillStyle = 'white';
@@ -164,7 +189,7 @@ export function drawPerceptionHighlights(ctx, player) {
   // highlight selected player
   ctx.beginPath();
   ctx.arc(player.x, player.y, player.radius + 4, 0, Math.PI * 2);
-  ctx.strokeStyle = "cyan";
+  ctx.strokeStyle = "yellow";
   ctx.stroke();
 
   for (const label in player.perceived) {


### PR DESCRIPTION
## Summary
- implement foul highlight indicator on the victim
- draw ball highlight when loose
- flash goal when a goal is scored
- mark the controlled player in yellow
- extend player timer updates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867dbfbb4488326a9df5e20d3abf6aa