### PR TITLE
Implement free kick handling on fouls

### DIFF
--- a/demo/soccer/referee.js
+++ b/demo/soccer/referee.js
@@ -1,8 +1,9 @@
 import { logComment } from './commentary.js';
 
 export class Referee {
-  constructor(onCardCallback) {
+  constructor(onCardCallback, onFoulCallback) {
     this.onCard = onCardCallback;
+    this.onFoul = onFoulCallback;
   }
 
   update(players, ball) {
@@ -31,5 +32,8 @@ export class Referee {
       logComment(`${victim.role} verletzt sich!`);
     }
     victim.highlightTimer = 1;
+    if (this.onFoul) {
+      this.onFoul(player, victim);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- expand referee with onFoul callback
- add free kick timer and handler
- pause gameplay when a foul occurs and resume after countdown

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867e14ef6e88326af8a8cc5fe45737e