### PR TITLE
Add radar view to soccer demo

### DIFF
--- a/demo/soccer/index.html
+++ b/demo/soccer/index.html
@@ -57,6 +57,12 @@
             width: 0%;
             background: linear-gradient(green, red);
         }
+        #radar {
+            display: block;
+            margin: 6px auto;
+            background: #065;
+            border: 2px solid white;
+        }
     </style>
 </head>
 <body>
@@ -86,6 +92,7 @@
   <span id="halftime">1. Halbzeit</span> &nbsp; | &nbsp;
   <span id="cards"></span>
 </div>
+    <canvas id="radar" width="210" height="136"></canvas>
     <div id="powerBarWrapper"><div id="powerBar"></div></div>
     <p style="text-align:center;margin-top:4px;">Spieler anklicken und mit Pfeiltasten oder Gamepad steuern</p>
     <canvas id="spielfeld" width="1050" height="680"></canvas>

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -2,7 +2,7 @@
 
 import { Player } from "./player.js";
 import { Coach } from "./coach.js";
-import { drawField, drawPlayers, drawBall, drawOverlay, drawZones, drawPasses, drawPerceptionHighlights, drawPassIndicator } from "./render.js";
+import { drawField, drawPlayers, drawBall, drawOverlay, drawZones, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar } from "./render.js";
 import { logComment } from "./commentary.js";
 import { Referee } from "./referee.js";
 
@@ -11,6 +11,8 @@ const canvas = document.getElementById("spielfeld");
 const ctx = canvas.getContext("2d");
 const powerBarWrapper = document.getElementById("powerBarWrapper");
 const powerBar = document.getElementById("powerBar");
+const radarCanvas = document.getElementById("radar");
+const radarCtx = radarCanvas.getContext("2d");
 
 const GameState = {
   FORMATION: "Formation wählen",
@@ -874,6 +876,7 @@ function gameLoop(timestamp) {
 
   drawBall(ctx, ball);
   drawOverlay(ctx, `Ball: ${ball.owner ? ball.owner.role : "Loose"} | Wetter: ${weather.type}`, canvas.width);
+  drawRadar(radarCtx, allPlayers, ball, radarCanvas.width, radarCanvas.height);
 
   // 8. Score/Goal Check/Timer
   checkGoal(ball);

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -222,3 +222,28 @@ export function drawPassIndicator(ctx, indicator) {
   ctx.setLineDash([]);
   ctx.restore();
 }
+
+export function drawRadar(ctx, players, ball, width, height) {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = '#065';
+  ctx.fillRect(0, 0, width, height);
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(0, 0, width, height);
+  ctx.beginPath();
+  ctx.moveTo(width / 2, 0);
+  ctx.lineTo(width / 2, height);
+  ctx.stroke();
+  const scaleX = width / 1050;
+  const scaleY = height / 680;
+  players.forEach(p => {
+    ctx.fillStyle = p.color;
+    ctx.beginPath();
+    ctx.arc(p.x * scaleX, p.y * scaleY, 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.fillStyle = 'white';
+  ctx.beginPath();
+  ctx.arc(ball.x * scaleX, ball.y * scaleY, 2, 0, Math.PI * 2);
+  ctx.fill();
+}


### PR DESCRIPTION
## Summary
- style radar canvas in soccer HTML
- display radar under the scoreboard
- render radar showing teams and ball

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867e3373ecc8326b27d4bb05d6ea474