### PR TITLE
Add goal highlight overlay

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -2,7 +2,7 @@
 
 import { Player } from "./player.js";
 import { Coach } from "./coach.js";
-import { drawField, drawPlayers, drawBall, drawOverlay, drawZones, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer } from "./render.js";
+import { drawField, drawPlayers, drawBall, drawOverlay, drawZones, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight } from "./render.js";
 import { logComment } from "./commentary.js";
 import { Referee } from "./referee.js";
 
@@ -53,6 +53,9 @@ let prevTackle = false;
 
 let goalFlashTimer = 0;
 let goalFlashSide = null;
+
+let goalOverlayTimer = 0;
+let goalOverlayText = '';
 
 // ----- Confetti particles for goal celebration -----
 let confettiParticles = [];
@@ -606,6 +609,8 @@ function checkGoal(ball) {
     logComment('Tor für Auswärtsteam!');
     goalFlashSide = 'left';
     goalFlashTimer = 1;
+    goalOverlayText = 'Tor für Auswärtsteam!';
+    goalOverlayTimer = 2;
     spawnConfetti('left');
     resetKickoff();
   }
@@ -615,6 +620,8 @@ function checkGoal(ball) {
     logComment('Tor für Heimteam!');
     goalFlashSide = 'right';
     goalFlashTimer = 1;
+    goalOverlayText = 'Tor für Heimteam!';
+    goalOverlayTimer = 2;
     spawnConfetti('right');
     resetKickoff();
   }
@@ -978,6 +985,7 @@ function gameLoop(timestamp) {
 
   drawBall(ctx, ball);
   drawOverlay(ctx, `Ball: ${ball.owner ? ball.owner.role : "Loose"} | Wetter: ${weather.type}`, canvas.width);
+  drawGoalHighlight(ctx, goalOverlayText, goalOverlayTimer, canvas.width, canvas.height);
   drawRadar(radarCtx, allPlayers, ball, radarCanvas.width, radarCanvas.height);
 
   // 8. Score/Goal Check/Timer
@@ -986,6 +994,10 @@ function gameLoop(timestamp) {
   if (goalFlashTimer > 0) {
     goalFlashTimer -= delta;
     if (goalFlashTimer < 0) goalFlashTimer = 0;
+  }
+  if (goalOverlayTimer > 0) {
+    goalOverlayTimer -= delta;
+    if (goalOverlayTimer < 0) goalOverlayTimer = 0;
   }
   if (currentState === GameState.RUNNING && matchTime - lastFormationSwitch > 30) {
     selectedFormationIndex = (selectedFormationIndex + 1) % formations.length;

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -285,3 +285,16 @@ export function drawRadar(ctx, players, ball, width, height) {
   ctx.arc(ball.x * scaleX, ball.y * scaleY, 2, 0, Math.PI * 2);
   ctx.fill();
 }
+
+export function drawGoalHighlight(ctx, text, timer, width, height) {
+  if (timer <= 0) return;
+  ctx.save();
+  ctx.globalAlpha = Math.min(1, timer / 2);
+  ctx.fillStyle = 'rgba(0,0,0,0.75)';
+  ctx.fillRect(0, height / 2 - 60, width, 120);
+  ctx.fillStyle = '#fff';
+  ctx.font = 'bold 48px Arial';
+  ctx.textAlign = 'center';
+  ctx.fillText(text, width / 2, height / 2 + 16);
+  ctx.restore();
+}


### PR DESCRIPTION
## Summary
- display overlay when goals are scored
- draw new overlay in render module

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867fd8065b8832687ea319ec267a754