### PR TITLE
Show player's perception only for selected agent

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -978,7 +978,10 @@ function gameLoop(timestamp) {
   drawPasses(ctx, allPlayers, ball);
   drawPassIndicator(ctx, passIndicator);
   drawConfetti(ctx);
-  drawPlayers(ctx, allPlayers, { showFOV: true, showRunDir: true, showHeadDir: true });
+  drawPlayers(ctx, allPlayers, { showFOV: false, showRunDir: true, showHeadDir: true });
+  if (selectedPlayer) {
+    drawPlayers(ctx, [selectedPlayer], { showFOV: true, showRunDir: true, showHeadDir: true });
+  }
   drawActivePlayer(ctx, selectedPlayer);
 
   drawPerceptionHighlights(ctx, selectedPlayer);


### PR DESCRIPTION
## Summary
- tweak soccer demo rendering so player's field of view (FOV) is only displayed for the currently selected player

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867fefb96b08326917a8ea7815804f7