### PR TITLE
Broaden soccer player zones

### DIFF
--- a/demo/soccer/decision-rules.js
+++ b/demo/soccer/decision-rules.js
@@ -63,6 +63,8 @@ function getAllowedZone(player, world) {
     case "ST": width = 320; height = 230; break;
     default: width = 170; height = 200; break;
   }
+  // Widen each role's zone to ensure the team collectively covers its half
+  width += 100;
 
   // --- Defensive PUSH: If ball is in our half, push formation up ---
   let push = 0;

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -149,6 +149,8 @@ export class Player {
       case "ST": width = 320; height = 230; break;
       default: width = 170; height = 200; break;
     }
+    // Widen each role's zone to ensure the team collectively covers its half
+    width += 100;
     const minX = Math.max(marginX, player.formationX - width / 2);
     const maxX = Math.min(1050 - marginX, player.formationX + width / 2);
     const minY = Math.max(marginY, player.formationY - height / 2);


### PR DESCRIPTION
## Summary
- enlarge tactical zones for every role so the team covers its half of the pitch

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867ff7cc2948326a015d9c19abc71ad