### PR TITLE
Add opponent analysis for soccer AI

### DIFF
--- a/demo/soccer/coach.js
+++ b/demo/soccer/coach.js
@@ -2,6 +2,7 @@ export class Coach {
   constructor(players) {
     this.players = players;
     this.pressing = 1;
+    this.attackSide = null; // 'left' or 'right'
   }
 
   setPressing(level) {
@@ -9,5 +10,15 @@ export class Coach {
     this.players.forEach(p => {
       p.mailbox.push({ from: 'coach', type: 'pressing', level });
     });
+  }
+
+  analyzeOpponents(ball, allies, opponents) {
+    let left = 0, right = 0;
+    for (const o of opponents) {
+      if (o.x < ball.x) left++; else right++;
+    }
+    if (left < right) this.attackSide = 'left';
+    else if (right < left) this.attackSide = 'right';
+    else this.attackSide = null;
   }
 }

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -80,6 +80,8 @@ const difficultyMultipliers = { easy: 0.8, normal: 1, hard: 1.2 };
 // --- Weather ---
 let weather = { type: "clear", windX: 0, windY: 0, friction: 0.97 };
 
+let lastAnalysis = 0;
+
 function applyWeather() {
   switch (weather.type) {
     case "wind":
@@ -753,6 +755,13 @@ function updateFormationOffsets() {
       formationOffsetAway.x += 20;
     }
   }
+  if (coach.attackSide === 'left') {
+    formationOffsetHome.x -= 15;
+    formationOffsetAway.x += 15;
+  } else if (coach.attackSide === 'right') {
+    formationOffsetHome.x += 15;
+    formationOffsetAway.x -= 15;
+  }
   formationOffsetHome.y = 0;
   formationOffsetAway.y = 0;
 }
@@ -762,6 +771,10 @@ function gameLoop(timestamp) {
   if (lastFrameTime === null) lastFrameTime = timestamp;
   const delta = (timestamp - lastFrameTime) / 1000;
   lastFrameTime = timestamp;
+  if (timestamp - lastAnalysis > 5000) {
+    coach.analyzeOpponents(ball, teamHeim, teamGast);
+    lastAnalysis = timestamp;
+  }
   if (freeKickTimer > 0) {
     freeKickTimer -= delta;
     ball.x = freeKickTaker.x;


### PR DESCRIPTION
## Summary
- add attackSide support and opponent analysis to `coach.js`
- call analysis periodically and adjust formation offsets in `main.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868015c971c83269f9452731e421143