### PR TITLE
Implement soft zone visualization

### DIFF
--- a/demo/soccer/TacticsHelper.js
+++ b/demo/soccer/TacticsHelper.js
@@ -1,0 +1,39 @@
+export function interpolate(a, b, t) {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}
+
+export function gaussianFalloff(dist, radius) {
+  if (radius <= 0) return 0;
+  const norm = dist / radius;
+  return Math.exp(-0.5 * norm * norm);
+}
+
+const baseRadii = {
+  TW: { rx: 70, ry: 60 },
+  IV: { rx: 90, ry: 80 },
+  LIV: { rx: 90, ry: 80 },
+  RIV: { rx: 90, ry: 80 },
+  LV: { rx: 100, ry: 90 },
+  RV: { rx: 100, ry: 90 },
+  DM: { rx: 110, ry: 100 },
+  ZM: { rx: 130, ry: 110 },
+  OM: { rx: 130, ry: 110 },
+  LM: { rx: 140, ry: 120 },
+  RM: { rx: 140, ry: 120 },
+  LF: { rx: 150, ry: 110 },
+  RF: { rx: 150, ry: 110 },
+  ST: { rx: 160, ry: 120 }
+};
+
+export function computeEllipseRadii(role, pressing = 1) {
+  const base = baseRadii[role] || { rx: 120, ry: 100 };
+  const factor = 1 / pressing; // higher pressing => smaller zones
+  return { rx: base.rx * factor, ry: base.ry * factor };
+}
+
+export function getTargetZoneCenter(player, ball, pressing = 1) {
+  const base = { x: player.formationX, y: player.formationY };
+  if (!ball) return base;
+  // move slightly toward the ball based on pressing
+  return interpolate(base, { x: ball.x, y: ball.y }, 0.15 * pressing);
+}

--- a/demo/soccer/coach.js
+++ b/demo/soccer/coach.js
@@ -3,6 +3,22 @@ export class Coach {
     this.players = players;
     this.pressing = 1;
     this.attackSide = null; // 'left' or 'right'
+    this.zoneSettings = {
+      ST: { radius: 160 },
+      LF: { radius: 150 },
+      RF: { radius: 150 },
+      OM: { radius: 130 },
+      ZM: { radius: 130 },
+      LM: { radius: 140 },
+      RM: { radius: 140 },
+      DM: { radius: 110 },
+      IV: { radius: 90 },
+      LIV: { radius: 90 },
+      RIV: { radius: 90 },
+      LV: { radius: 100 },
+      RV: { radius: 100 },
+      TW: { radius: 70 },
+    };
   }
 
   setPressing(level) {
@@ -21,4 +37,11 @@ export class Coach {
     else if (right < left) this.attackSide = 'right';
     else this.attackSide = null;
   }
+
+  getZoneParameters(role) {
+    const base = this.zoneSettings[role] || { radius: 120 };
+    const factor = 1 / this.pressing;
+    return { radius: base.radius * factor };
+  }
 }
+

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -2,7 +2,7 @@
 
 import { Player } from "./player.js";
 import { Coach } from "./coach.js";
-import { drawField, drawPlayers, drawBall, drawOverlay, drawZones, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight } from "./render.js";
+import { drawField, drawPlayers, drawBall, drawOverlay, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight, drawSoftZones } from "./render.js";
 import { logComment } from "./commentary.js";
 import { Referee } from "./referee.js";
 
@@ -792,7 +792,7 @@ function gameLoop(timestamp) {
     ball.owner = freeKickTaker;
     const allPlayers = [...teamHeim, ...teamGast];
     drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
-    drawZones(ctx, allPlayers, { home: formationOffsetHome, away: formationOffsetAway });
+    drawSoftZones(ctx, allPlayers, ball, coach);
     drawPlayers(ctx, allPlayers);
     drawBall(ctx, ball);
     drawOverlay(ctx, `Freistoß: ${freeKickTimer.toFixed(1)}s`, canvas.width);
@@ -1004,7 +1004,7 @@ function gameLoop(timestamp) {
 
   // 7. RENDER
   drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
-  drawZones(ctx, allPlayers, { home: formationOffsetHome, away: formationOffsetAway });
+  drawSoftZones(ctx, allPlayers, ball, coach);
   drawPasses(ctx, allPlayers, ball);
   drawPassIndicator(ctx, passIndicator);
   drawConfetti(ctx);

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -1,5 +1,6 @@
 import { Capabilities } from './capabilities.js';
 import { createPlayerBT } from "./footBallBTs.js";
+import { computeEllipseRadii, getTargetZoneCenter } from "./TacticsHelper.js";
 
 
 const TradeProfiles = {
@@ -164,6 +165,13 @@ export class Player {
       x: Math.max(zone.minX, Math.min(zone.maxX, x)),
       y: Math.max(zone.minY, Math.min(zone.maxY, y)),
     };
+  }
+
+  static getDynamicTargetZone(player, ball, coach) {
+    const pressing = coach ? coach.pressing : 1;
+    const center = getTargetZoneCenter(player, ball, pressing);
+    const radii = computeEllipseRadii(player.role, pressing);
+    return { x: center.x, y: center.y, rx: radii.rx, ry: radii.ry };
   }
 
   // --- Boni/Mali aus Trade-System holen ---

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -220,6 +220,26 @@ export function drawZones(ctx, players, offsets = { home: {x:0,y:0}, away: {x:0,
   ctx.restore();
 }
 
+export function drawSoftZones(ctx, players, ball, coach) {
+  ctx.save();
+  players.forEach(p => {
+    const zone = p.constructor.getDynamicTargetZone ?
+      p.constructor.getDynamicTargetZone(p, ball, coach) : null;
+    if (!zone) return;
+    ctx.translate(zone.x, zone.y);
+    ctx.scale(zone.rx, zone.ry);
+    const grad = ctx.createRadialGradient(0, 0, 0, 0, 0, 1);
+    grad.addColorStop(0, `${p.color}66`);
+    grad.addColorStop(1, `${p.color}00`);
+    ctx.fillStyle = grad;
+    ctx.beginPath();
+    ctx.arc(0, 0, 1, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+  });
+  ctx.restore();
+}
+
 export function drawPerceptionHighlights(ctx, player) {
   if (!player) return;
   ctx.save();
@@ -298,3 +318,4 @@ export function drawGoalHighlight(ctx, text, timer, width, height) {
   ctx.fillText(text, width / 2, height / 2 + 16);
   ctx.restore();
 }
+


### PR DESCRIPTION
## Summary
- create `TacticsHelper` with interpolation and ellipse helpers
- extend `Coach` with zone parameters
- compute dynamic soft zones in `Player`
- render soft zones with gradients
- use soft zones in the match loop

## Testing
- `node -e "import('./demo/soccer/TacticsHelper.js')"`
- `node -e "import('./demo/soccer/player.js')"`
- `node -e "import('./demo/soccer/coach.js')"`
- `node -e "import('./demo/soccer/render.js')"`
- `node -e "import('./demo/soccer/main.js').catch(e=>console.error(e.message))"` (fails: document is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68680b653ac483269aecb42828d3a532