### PR TITLE
Add German tasks for UI control panel

### DIFF
--- a/TASKS-UI.md
+++ b/TASKS-UI.md
@@ -1,0 +1,14 @@
+# Zentrale Spielübersicht & Einstellungsmenü
+
+Ziel: Ein in-Canvas oder seitlich einblendbares Panel, das als "Command-Center" für Spielkontrolle, Debugging und Individualisierung dient.
+
+## Modulübersicht – Funktionen und Tabs
+
+- [ ] 🎮 **Eingabebelegung** – Keybinds einsehen & anpassen (z.​​​​B. Pass = Space, Abbrechen = Backspace, Shot = S, Lob = Shift)
+- [ ] 🧠 **Spielerwerte** – Zeige Stats (Speed, Technique, Vision, etc.) aller Spieler mit Filter (Team, Position)
+- [ ] 🧩 **Formation / Aufstellung** – Graphische Anzeige der Teamformation, ggf. auch Wechseloptionen
+- [ ] 🌱 **Pitch Info** – Eigenschaften des Spielfeldes anzeigen: Maße, Grasart, Friktion, Witterung (optional)
+- [ ] 🧪 **Debugging** – Aktuelle Zustände: Spieler-Zonen, Sichtfelder, Ball-Vector, Entscheidungen (z. „Wird tackle vorbereitet“)
+- [ ] 🎨 **Darstellung** – Farbprofile, Linien-Transparenz, Debug-Overlays ein-/ausblendbar
+- [ ] 💾 **Live-Daten** – JSON-Snapshot von Welt, Spielern & Match-State zur Ansicht & Download
+- [ ] 💬 **Log / Console** – Letzte Events (z. „Tackle ausgeführt“, „Ballbesitz verloren“)


### PR DESCRIPTION
## Summary
- replace English TASKS-UI notes with the original German bullet list

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868303882a88326ab5e3d4d0c4a8035