### PR TITLE
Adjust soccer zones and ball friction

### DIFF
--- a/demo/soccer/ball.js
+++ b/demo/soccer/ball.js
@@ -9,8 +9,8 @@ export class Ball {
     this.angularVelocity = 0;
     this.radius = 6;
     this.mass = 0.43; // kg
-    // Use a gentler friction so passes keep momentum
-    this.friction = 0.995;
+    // Use a gentler friction so passes keep momentum longer
+    this.friction = 0.998;
     this.spinFriction = 0.985;
     this.restitution = 0.7;
     this.owner = null;

--- a/demo/soccer/decision-rules.js
+++ b/demo/soccer/decision-rules.js
@@ -50,7 +50,7 @@ function playerIsClosestToBall(player, world) {
 
 // ---- Tactical Zone Definition ----
 function getAllowedZone(player, world) {
-  let marginX = 35, marginY = 25;
+  let marginX = 20, marginY = 15;
   let width = 160, height = 180;
   switch (player.role) {
     case "TW": width = 80; height = 140; break;
@@ -64,7 +64,8 @@ function getAllowedZone(player, world) {
     default: width = 170; height = 200; break;
   }
   // Widen each role's zone to ensure the team collectively covers its half
-  width += 100;
+  width += 200;
+  height += 80;
 
   // --- Defensive PUSH: If ball is in our half, push formation up ---
   let push = 0;

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -131,7 +131,7 @@ const difficultyMultipliers = { easy: 0.8, normal: 1, hard: 1.2 };
 
 // --- Weather ---
 // Higher friction values closer to 1 mean less slowdown per frame
-window.weather = { type: "clear", windX: 0, windY: 0, friction: 0.995 };
+window.weather = { type: "clear", windX: 0, windY: 0, friction: 0.998 };
 const weather = window.weather;
 
 let lastAnalysis = 0;
@@ -141,17 +141,17 @@ function applyWeather() {
     case "wind":
       weather.windX = 0.03;
       weather.windY = 0.01;
-      weather.friction = 0.995;
+      weather.friction = 0.998;
       break;
     case "rain":
       weather.windX = 0;
       weather.windY = 0;
-      weather.friction = 0.99;
+      weather.friction = 0.995;
       break;
     default:
       weather.windX = 0;
       weather.windY = 0;
-      weather.friction = 0.995;
+      weather.friction = 0.998;
   }
 }
 

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -136,7 +136,7 @@ export class Player {
 
   static getAllowedZone(player) {
     // These must match decision-rules.js
-    let marginX = 35, marginY = 25;
+    let marginX = 20, marginY = 15;
     let width = 160, height = 180;
 
     switch (player.role) {
@@ -151,7 +151,8 @@ export class Player {
       default: width = 170; height = 200; break;
     }
     // Widen each role's zone to ensure the team collectively covers its half
-    width += 100;
+    width += 200;
+    height += 80;
     const minX = Math.max(marginX, player.formationX - width / 2);
     const maxX = Math.min(1050 - marginX, player.formationX + width / 2);
     const minY = Math.max(marginY, player.formationY - height / 2);


### PR DESCRIPTION
## Summary
- enlarge tactical allowed zones for players
- slow down ball friction decay
- tune default weather friction values

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68685ad31b508326aabb248a032942e6