### PR TITLE
Add dynamic allowed zones

### DIFF
--- a/demo/soccer/decision-rules.js
+++ b/demo/soccer/decision-rules.js
@@ -91,6 +91,57 @@ function clampToZone(x, y, zone) {
   };
 }
 
+// --- New dynamic allowed zone relative to the ball ---
+export function allowedZone(player, world) {
+  const { ball } = world;
+  const centerX = ball ? ball.x : player.formationX;
+  const centerY = ball ? ball.y : player.formationY;
+
+  let zoneWidth = 200;
+  let zoneHeight = 200;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  switch (player.role) {
+    case "TW":
+      zoneWidth = 100; zoneHeight = 150;
+      offsetX = player.color === "blue" ? -300 : 300;
+      break;
+    case "IV": case "LIV": case "RIV":
+      zoneWidth = 140; zoneHeight = 200;
+      offsetX = player.color === "blue" ? -150 : 150;
+      break;
+    case "DM":
+      zoneWidth = 180; zoneHeight = 240;
+      offsetX = player.color === "blue" ? -80 : 80;
+      break;
+    case "ZM": case "OM":
+      zoneWidth = 250; zoneHeight = 250;
+      offsetX = 0;
+      break;
+    case "LM": case "RM":
+      zoneWidth = 200; zoneHeight = 300;
+      offsetY = (player.role === "LM" ? -150 : 150);
+      break;
+    case "LF": case "RF":
+      zoneWidth = 200; zoneHeight = 180;
+      offsetX = player.color === "blue" ? 100 : -100;
+      offsetY = (player.role === "LF" ? -80 : 80);
+      break;
+    case "ST":
+      zoneWidth = 180; zoneHeight = 150;
+      offsetX = player.color === "blue" ? 160 : -160;
+      break;
+  }
+
+  return {
+    x: centerX + offsetX - zoneWidth / 2,
+    y: centerY + offsetY - zoneHeight / 2,
+    width: zoneWidth,
+    height: zoneHeight
+  };
+}
+
 
 
 export function decidePlayerAction(player, world, gameState) {

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -1073,7 +1073,12 @@ function gameLoop(timestamp) {
   }
 
   // 4. Spieler bewegen
-  allPlayers.forEach(p => p.moveToTarget());
+  allPlayers.forEach(p => {
+    const myTeam = teamHeim.includes(p) ? teamHeim : teamGast;
+    const otherTeam = teamHeim.includes(p) ? teamGast : teamHeim;
+    const world = { ball, teammates: myTeam, opponents: otherTeam };
+    p.moveToTarget(world);
+  });
   allPlayers.forEach(p => p.updateHead(ball, delta, {
     teammates: teamHeim.includes(p) ? teamHeim : teamGast,
     opponents: teamHeim.includes(p) ? teamGast : teamHeim

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -168,6 +168,63 @@ export class Player {
     };
   }
 
+  static clampToRect(x, y, zone) {
+    return {
+      x: Math.max(zone.x, Math.min(zone.x + zone.width, x)),
+      y: Math.max(zone.y, Math.min(zone.y + zone.height, y)),
+    };
+  }
+
+  static getDynamicZone(player, world) {
+    const { ball } = world;
+    const centerX = ball ? ball.x : player.formationX;
+    const centerY = ball ? ball.y : player.formationY;
+
+    let zoneWidth = 200;
+    let zoneHeight = 200;
+    let offsetX = 0;
+    let offsetY = 0;
+
+    switch (player.role) {
+      case "TW":
+        zoneWidth = 100; zoneHeight = 150;
+        offsetX = player.color === "blue" ? -300 : 300;
+        break;
+      case "IV": case "LIV": case "RIV":
+        zoneWidth = 140; zoneHeight = 200;
+        offsetX = player.color === "blue" ? -150 : 150;
+        break;
+      case "DM":
+        zoneWidth = 180; zoneHeight = 240;
+        offsetX = player.color === "blue" ? -80 : 80;
+        break;
+      case "ZM": case "OM":
+        zoneWidth = 250; zoneHeight = 250;
+        offsetX = 0;
+        break;
+      case "LM": case "RM":
+        zoneWidth = 200; zoneHeight = 300;
+        offsetY = (player.role === "LM" ? -150 : 150);
+        break;
+      case "LF": case "RF":
+        zoneWidth = 200; zoneHeight = 180;
+        offsetX = player.color === "blue" ? 100 : -100;
+        offsetY = (player.role === "LF" ? -80 : 80);
+        break;
+      case "ST":
+        zoneWidth = 180; zoneHeight = 150;
+        offsetX = player.color === "blue" ? 160 : -160;
+        break;
+    }
+
+    return {
+      x: centerX + offsetX - zoneWidth / 2,
+      y: centerY + offsetY - zoneHeight / 2,
+      width: zoneWidth,
+      height: zoneHeight,
+    };
+  }
+
   static getDynamicTargetZone(player, ball, coach) {
     const pressing = coach ? coach.pressing : 1;
     const zoneParams = coach ? coach.getZoneParameters(player.role) : null;
@@ -231,12 +288,12 @@ export class Player {
     }
   }
 
-  moveToTarget() {
+  moveToTarget(world = null) {
     if (this.sliding) {
       this.x += this.slideDirX * this.slideSpeed;
       this.y += this.slideDirY * this.slideSpeed;
-      const zone = Player.getAllowedZone(this);
-      const pos = Player.clampToZone(this.x, this.y, zone);
+      const zone = world ? Player.getDynamicZone(this, world) : Player.getAllowedZone(this);
+      const pos = world ? Player.clampToRect(this.x, this.y, zone) : Player.clampToZone(this.x, this.y, zone);
       this.x = pos.x;
       this.y = pos.y;
       this.slideTimer--;
@@ -250,6 +307,9 @@ export class Player {
     }
 
     this.updateDirectionTowardsTarget();
+    const zoneMove = world ? Player.getDynamicZone(this, world) : Player.getAllowedZone(this);
+    this.targetX = world ? Math.max(zoneMove.x, Math.min(zoneMove.x + zoneMove.width, this.targetX)) : this.targetX;
+    this.targetY = world ? Math.max(zoneMove.y, Math.min(zoneMove.y + zoneMove.height, this.targetY)) : this.targetY;
     const dx = this.targetX - this.x;
     const dy = this.targetY - this.y;
     const dist = Math.hypot(dx, dy);
@@ -263,8 +323,8 @@ export class Player {
       this.vy = this.vy + (desiredVy - this.vy) * smooth;
       this.x += this.vx;
       this.y += this.vy;
-      const zone = Player.getAllowedZone(this);
-      const pos = Player.clampToZone(this.x, this.y, zone);
+      const zone = world ? Player.getDynamicZone(this, world) : Player.getAllowedZone(this);
+      const pos = world ? Player.clampToRect(this.x, this.y, zone) : Player.clampToZone(this.x, this.y, zone);
       this.x = pos.x;
       this.y = pos.y;
       const movement = Math.hypot(this.vx, this.vy);


### PR DESCRIPTION
## Summary
- implement `allowedZone` in decision-rules.js to compute zones relative to the ball
- expose matching `getDynamicZone` in `player.js` with helper clamp function
- update player movement to clamp targets and position within the dynamic zone
- pass world info to movement in main game loop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868df05220083268a8653075cbebfe7