### PR TITLE
Implement basic soccer restarts and physics tracking

### DIFF
--- a/demo/soccer/capabilities.js
+++ b/demo/soccer/capabilities.js
@@ -12,7 +12,7 @@ export const Capabilities = {
     const offset = player.radius + ball.radius + 2;
     const startX = player.x + (dx / dist) * offset;
     const startY = player.y + (dy / dist) * offset;
-    ball.kick(startX, startY, dx, dy, 20, spin);
+    ball.kick(startX, startY, dx, dy, 20, spin, player);
     player.currentAction = 'shoot';
   },
 
@@ -29,7 +29,7 @@ export const Capabilities = {
     const offset = player.radius + ball.radius + 2;
     const startX = player.x + (dx / dist) * offset;
     const startY = player.y + (dy / dist) * offset;
-    ball.kick(startX, startY, dx, dy, 12, spin);
+    ball.kick(startX, startY, dx, dy, 12, spin, player);
     player.currentAction = 'pass';
   },
 
@@ -45,7 +45,7 @@ export const Capabilities = {
     const offset = player.radius + ball.radius + 2;
     const startX = player.x + (dx / dist) * offset;
     const startY = player.y + (dy / dist) * offset;
-    ball.kick(startX, startY, dx, dy, 10, spin);
+    ball.kick(startX, startY, dx, dy, 10, spin, player);
     ball.vy -= 2; // simple lift
     player.currentAction = 'lobPass';
   },


### PR DESCRIPTION
## Summary
- extend `Ball` with `lastTouch` and `outOfBounds`
- detect when the ball leaves the field and trigger throw‑ins, corners or goal kicks
- track last player touching the ball and pass kicker through capabilities
- pause gameplay during restarts for a short timer

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869074110a4832695511f52e98f8900