### PR TITLE
Implement dynamic player zones

### DIFF
--- a/demo/soccer/decision-rules.js
+++ b/demo/soccer/decision-rules.js
@@ -92,10 +92,10 @@ function clampToZone(x, y, zone) {
 }
 
 // --- New dynamic allowed zone relative to the ball ---
-export function allowedZone(player, world) {
-  const { ball } = world;
-  const centerX = ball ? ball.x * 0.6 + player.formationX * 0.4 : player.formationX;
-  const centerY = ball ? ball.y * 0.6 + player.formationY * 0.4 : player.formationY;
+export function getDynamicZone(player, world) {
+  const { ball, tactic } = world;
+  const centerX = ball ? ball.x : player.formationX;
+  const centerY = ball ? ball.y : player.formationY;
 
   let zoneWidth = 200;
   let zoneHeight = 200;
@@ -132,6 +132,20 @@ export function allowedZone(player, world) {
       zoneWidth = 180; zoneHeight = 150;
       offsetX = player.color === "blue" ? 160 : -160;
       break;
+  }
+
+  // adjust width/height and offsets by tactical state / pressing
+  const pressing = player.pressing ?? 1;
+  if (tactic === 'pressing') {
+    zoneWidth *= 1 / pressing;
+    zoneHeight *= 1 / pressing;
+    offsetX *= pressing;
+    offsetY *= pressing;
+  } else if (tactic === 'zurückgezogen') {
+    zoneWidth *= 1.2;
+    zoneHeight *= 1.2;
+    offsetX *= 0.6;
+    offsetY *= 0.6;
   }
 
   return {

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -3,7 +3,7 @@
 import { Player } from "./player.js";
 import { Coach } from "./coach.js";
 import { Ball, FIELD_BOUNDS } from "./ball.js";
-import { drawField, drawPlayers, drawBall, drawOverlay, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight, drawSoftZones, drawBallDebug } from "./render.js";
+import { drawField, drawPlayers, drawBall, drawOverlay, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight, drawZones, drawBallDebug } from "./render.js";
 import { logComment } from "./commentary.js";
 import { initControlPanel } from "./ui-panel.js";
 import { Referee } from "./referee.js";
@@ -927,7 +927,7 @@ function gameLoop(timestamp) {
     const allPlayers = [...teamHeim, ...teamGast];
     drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
     if (window.debugOptions.showZones) {
-      drawSoftZones(ctx, allPlayers, ball, coach, { heatmap: true });
+      drawZones(ctx, allPlayers, { ball, tactic: coach?.pressing > 1 ? 'pressing' : null });
     }
     drawPlayers(ctx, allPlayers);
     drawBall(ctx, ball);
@@ -947,7 +947,7 @@ function gameLoop(timestamp) {
     const allPlayers = [...teamHeim, ...teamGast];
     drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
     if (window.debugOptions.showZones) {
-      drawSoftZones(ctx, allPlayers, ball, coach, { heatmap: true });
+      drawZones(ctx, allPlayers, { ball, tactic: coach?.pressing > 1 ? 'pressing' : null });
     }
     drawPlayers(ctx, allPlayers);
     drawBall(ctx, ball);
@@ -1238,7 +1238,7 @@ function gameLoop(timestamp) {
   // 7. RENDER
   drawField(ctx, canvas.width, canvas.height, goalFlashTimer, goalFlashSide);
   if (window.debugOptions.showZones) {
-    drawSoftZones(ctx, allPlayers, ball, coach, { heatmap: true });
+    drawZones(ctx, allPlayers, { ball, tactic: coach?.pressing > 1 ? 'pressing' : null });
   }
   drawPasses(ctx, allPlayers, ball);
   drawPassIndicator(ctx, passIndicator);

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -1,7 +1,7 @@
 import { Capabilities } from './capabilities.js';
 import { createPlayerBT } from "./footBallBTs.js";
 import { computeEllipseRadii, getTargetZoneCenter } from "./TacticsHelper.js";
-import { allowedZone } from "./decision-rules.js";
+import { getDynamicZone } from "./decision-rules.js";
 
 
 const TradeProfiles = {
@@ -246,7 +246,7 @@ export class Player {
       this.x += this.slideDirX * this.slideSpeed;
       this.y += this.slideDirY * this.slideSpeed;
 
-      const zone = world ? allowedZone(this, world) : Player.getAllowedZone(this);
+      const zone = world ? getDynamicZone(this, world) : Player.getAllowedZone(this);
 
       const pos = world ? Player.clampToRect(this.x, this.y, zone, 20) : Player.clampToZone(this.x, this.y, zone);
       this.x = pos.x;
@@ -263,7 +263,7 @@ export class Player {
 
     this.updateDirectionTowardsTarget();
 
-    const zoneMove = world ? allowedZone(this, world) : Player.getAllowedZone(this);
+    const zoneMove = world ? getDynamicZone(this, world) : Player.getAllowedZone(this);
 
     this.targetX = world ? Math.max(zoneMove.x, Math.min(zoneMove.x + zoneMove.width, this.targetX)) : this.targetX;
     this.targetY = world ? Math.max(zoneMove.y, Math.min(zoneMove.y + zoneMove.height, this.targetY)) : this.targetY;
@@ -281,7 +281,7 @@ export class Player {
       this.x += this.vx;
       this.y += this.vy;
 
-      const zone = world ? allowedZone(this, world) : Player.getAllowedZone(this);
+      const zone = world ? getDynamicZone(this, world) : Player.getAllowedZone(this);
 
       const pos = world ? Player.clampToRect(this.x, this.y, zone, 20) : Player.clampToZone(this.x, this.y, zone);
       this.x = pos.x;

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -1,5 +1,6 @@
 // render.js
 import { gaussianFalloff, alphaHex } from "./TacticsHelper.js";
+import { getDynamicZone } from "./decision-rules.js";
 let fieldCache = null;
 let fieldCacheWidth = 0;
 let fieldCacheHeight = 0;
@@ -204,19 +205,18 @@ export function drawOverlay(ctx, text, width) {
     ctx.fillText(text, 20, 28);
 }
 
-export function drawZones(ctx, players, offsets = { home: {x:0,y:0}, away: {x:0,y:0} }) {
+export function drawZones(ctx, players, world, offsets = { home: {x:0,y:0}, away: {x:0,y:0} }) {
   ctx.save();
   players.forEach(p => {
-    // Use the same getAllowedZone logic as in player.js/decision-rules.js!
-    const zone = p.constructor.getAllowedZone ? p.constructor.getAllowedZone(p) : getAllowedZone(p);
+    const zone = getDynamicZone(p, world);
     const off = (p.color === '#0000ff') ? offsets.home : offsets.away;
-    zone.minX += off.x; zone.maxX += off.x; zone.minY += off.y; zone.maxY += off.y;
+    zone.x += off.x; zone.y += off.y;
     ctx.globalAlpha = 0.15 * (window.renderOptions?.lineAlpha ?? 1);
     ctx.strokeStyle = p.color;
     ctx.fillStyle = p.color;
     ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.rect(zone.minX, zone.minY, zone.maxX - zone.minX, zone.maxY - zone.minY);
+    ctx.rect(zone.x, zone.y, zone.width, zone.height);
     ctx.stroke();
     ctx.globalAlpha = 0.08 * (window.renderOptions?.lineAlpha ?? 1);
     ctx.fill();


### PR DESCRIPTION
## Summary
- implement `getDynamicZone` for ball-relative player zones
- clamp movement in `moveToTarget` using the new zone
- draw current zones with `drawZones`
- visualise zones during gameplay

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68690de1b610832695a3b911e28ab4dc