### PR TITLE
Fix players leaving pitch

### DIFF
--- a/demo/soccer/decision-rules.js
+++ b/demo/soccer/decision-rules.js
@@ -1,4 +1,5 @@
 // decision-rules.js
+import { FIELD_BOUNDS } from './ball.js';
 
 export function canPass(player, world) {
     if (!world.ball || !world.ball.isLoose) return false;
@@ -148,12 +149,12 @@ export function getDynamicZone(player, world) {
     offsetY *= 0.6;
   }
 
-  return {
-    x: centerX + offsetX - zoneWidth / 2,
-    y: centerY + offsetY - zoneHeight / 2,
-    width: zoneWidth,
-    height: zoneHeight
-  };
+  let x = centerX + offsetX - zoneWidth / 2;
+  let y = centerY + offsetY - zoneHeight / 2;
+  x = Math.max(FIELD_BOUNDS.minX, Math.min(FIELD_BOUNDS.maxX - zoneWidth, x));
+  y = Math.max(FIELD_BOUNDS.minY, Math.min(FIELD_BOUNDS.maxY - zoneHeight, y));
+
+  return { x, y, width: zoneWidth, height: zoneHeight };
 }
 
 
@@ -257,7 +258,9 @@ function decideBallOwnerAction(player, world) {
 // ---- Intent Resolver (bounds action to zone) ----
 function boundedIntent(player, intent, tx, ty, world, allowOutside = false) {
   const zone = getAllowedZone(player, world);
-  const target = allowOutside ? { x: tx, y: ty } : clampToZone(tx, ty, zone);
+  let target = allowOutside ? { x: tx, y: ty } : clampToZone(tx, ty, zone);
+  target.x = Math.max(FIELD_BOUNDS.minX, Math.min(FIELD_BOUNDS.maxX, target.x));
+  target.y = Math.max(FIELD_BOUNDS.minY, Math.min(FIELD_BOUNDS.maxY, target.y));
   player.targetX = target.x;
   player.targetY = target.y;
   player.currentAction = intent;

--- a/demo/soccer/player.js
+++ b/demo/soccer/player.js
@@ -2,6 +2,7 @@ import { Capabilities } from './capabilities.js';
 import { createPlayerBT } from "./footBallBTs.js";
 import { computeEllipseRadii, getTargetZoneCenter } from "./TacticsHelper.js";
 import { getDynamicZone } from "./decision-rules.js";
+import { FIELD_BOUNDS } from "./ball.js";
 
 
 const TradeProfiles = {
@@ -163,16 +164,21 @@ export class Player {
   }
 
   static clampToZone(x, y, zone) {
-    return {
-      x: Math.max(zone.minX, Math.min(zone.maxX, x)),
-      y: Math.max(zone.minY, Math.min(zone.maxY, y)),
-    };
+    const cx = Math.max(zone.minX, Math.min(zone.maxX, x));
+    const cy = Math.max(zone.minY, Math.min(zone.maxY, y));
+    return Player.clampToField(cx, cy);
   }
 
   static clampToRect(x, y, zone, margin = 0) {
+    const rx = Math.max(zone.x - margin, Math.min(zone.x + zone.width + margin, x));
+    const ry = Math.max(zone.y - margin, Math.min(zone.y + zone.height + margin, y));
+    return Player.clampToField(rx, ry);
+  }
+
+  static clampToField(x, y, bounds = FIELD_BOUNDS) {
     return {
-      x: Math.max(zone.x - margin, Math.min(zone.x + zone.width + margin, x)),
-      y: Math.max(zone.y - margin, Math.min(zone.y + zone.height + margin, y)),
+      x: Math.max(bounds.minX, Math.min(bounds.maxX, x)),
+      y: Math.max(bounds.minY, Math.min(bounds.maxY, y)),
     };
   }
 


### PR DESCRIPTION
## Summary
- enforce field boundaries for player zones and movement
- keep dynamic target zones inside pitch

## Testing
- `npm run build` *(fails: npm attempted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68692508153c8326945a9b2c53cc1a47