### PR TITLE
Add match structure doc and zone tests

### DIFF
--- a/MATCH_STRUCTURE.md
+++ b/MATCH_STRUCTURE.md
@@ -1,0 +1,11 @@
+# Official Soccer Match Structure
+
+This document summarizes the standard flow of a professional soccer match.
+
+1. **Kick-off** – Play begins with a kick-off at the centre spot.
+2. **First Half** – 45 minutes of play plus any stoppage time added by the referee.
+3. **Half-time** – A 15 minute break. Teams switch ends of the field.
+4. **Second Half** – Another 45 minutes of play plus stoppage time.
+5. **Full Time** – The match concludes after the second-half stoppage time.
+
+In knockout competitions the game may proceed to **extra time** (two 15 minute periods) if the score is level. If still tied, the winner is decided by a **penalty shoot-out**.

--- a/test/formation.test.cjs
+++ b/test/formation.test.cjs
@@ -32,4 +32,15 @@ const spawned = spawnPlayers(formations[0], 'home');
 assert.equal(spawned.length, 11);
 assert.equal(spawned[0].formationX, formations[0].players[0].x);
 
+const zoneHome = getDynamicZone({ formationX: 100, formationY: 200, role: 'ST', side: 'home' }, world);
+const zoneAway = getDynamicZone({ formationX: 100, formationY: 200, role: 'ST', side: 'away' }, world);
+assert(zoneHome.x > zoneAway.x, 'away zone should mirror x-offset');
+
+const zoneFallback = getDynamicZone(player, { ball: null });
+const expected = player.formationX + DEFAULT_ROLE_CONFIG.ST.offsetX - DEFAULT_ROLE_CONFIG.ST.width / 2;
+assert.equal(zoneFallback.x, expected);
+
+const spawnedAway = spawnPlayers(formations[0], 'away');
+assert.equal(spawnedAway[0].formationX, 1050 - formations[0].players[0].x);
+
 console.log('tests passed');


### PR DESCRIPTION
## Summary
- document standard soccer match structure
- expand formation tests to check zone calculation for both sides and fallback

## Testing
- `npm run build`
- `node test/formation.test.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68693a6252908326b2d6409d658bcf5b