### PR TITLE
Add reset control for soccer demo

### DIFF
--- a/demo/soccer/index.html
+++ b/demo/soccer/index.html
@@ -98,7 +98,7 @@
 </div>
     <canvas id="radar" width="210" height="136"></canvas>
     <div id="powerBarWrapper"><div id="powerBar"></div></div>
-    <p style="text-align:center;margin-top:4px;">Spieler anklicken und mit Pfeiltasten oder Gamepad steuern</p>
+    <p style="text-align:center;margin-top:4px;">Spieler anklicken und mit Pfeiltasten oder Gamepad steuern &ndash; 'R' setzt das Spiel zurück</p>
     <canvas id="spielfeld" width="1050" height="680"></canvas>
     <div id="commentary"></div>
     <script type="module" src="main.js"></script>

--- a/demo/soccer/input.js
+++ b/demo/soccer/input.js
@@ -11,6 +11,7 @@ export const defaultBindings = {
   cancel: ["KeyC"],
   switchPlayer: ["Tab"],
   slide: ["KeyX"],
+  reset: ["KeyR"],
 };
 
 function arr(val) {
@@ -36,8 +37,11 @@ export class InputHandler {
       slideUp: false,
       cancel: false,
       switch: false,
+      reset: false,
+      resetDown: false,
+      resetUp: false,
     };
-    this.prevButtons = { pass: false, shoot: false, slide: false };
+    this.prevButtons = { pass: false, shoot: false, slide: false, reset: false };
     this.cooldowns = { pass: 0, shoot: 0, slide: 0 };
 
     window.addEventListener("keydown", e => this.onKeyDown(e));
@@ -79,6 +83,7 @@ export class InputHandler {
       cancel: arr(kb.cancel || this.bindings.cancel),
       switchPlayer: arr(kb.switch || this.bindings.switchPlayer),
       slide: arr(kb.tackle || this.bindings.slide),
+      reset: arr(kb.reset || this.bindings.reset),
     };
 
     // Direction from keyboard
@@ -95,6 +100,7 @@ export class InputHandler {
     let sprint = this._isPressed(b.sprint);
     let cancel = this._isPressed(b.cancel);
     let sw = this._isPressed(b.switchPlayer);
+    let rst = this._isPressed(b.reset);
 
     // Gamepad overrides
     if (this.gamepadIndex !== null) {
@@ -119,6 +125,10 @@ export class InputHandler {
     s.sprint = sprint;
     s.cancel = cancel;
     s.switch = sw;
+    s.resetDown = !this.prevButtons.reset && rst;
+    s.resetUp = this.prevButtons.reset && !rst;
+    s.reset = rst;
+    this.prevButtons.reset = rst;
 
     s.passDown = !this.prevButtons.pass && pass;
     s.passUp = this.prevButtons.pass && !pass;

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -74,7 +74,10 @@ const userInput = {
   shootUp: false,
   tacklePressed: false,
   tackleDown: false,
-  tackleUp: false
+  tackleUp: false,
+  resetPressed: false,
+  resetDown: false,
+  resetUp: false
 };
 let selectedPlayer2 = null;
 let userTeam2 = teamGast;
@@ -788,6 +791,7 @@ function resetGame() {
   resetKickoff();
   updateScoreboard();
   logComment('Spiel zurückgesetzt');
+  matchPaused = false;
 }
 
 
@@ -862,6 +866,9 @@ function updateUserInput(delta) {
   userInput.tacklePressed = state.slide;
   userInput.tackleDown = state.slideDown;
   userInput.tackleUp = state.slideUp;
+  userInput.resetPressed = state.reset;
+  userInput.resetDown = state.resetDown;
+  userInput.resetUp = state.resetUp;
 
   if (state.switch) {
     switchToNearestPlayer(userTeam);
@@ -965,6 +972,10 @@ function gameLoop(timestamp) {
   }
   updateUserInput(delta);
   updateUserInput2();
+  if (userInput.resetDown) {
+    resetGame();
+    matchPaused = false;
+  }
   updateFormationOffsets();
   if (selectedPlayer) {
     const active = Math.abs(userInput.dx) > 0.01 || Math.abs(userInput.dy) > 0.01;
@@ -1270,6 +1281,9 @@ function gameLoop(timestamp) {
   drawOverlay(ctx, `Ball: ${ball.owner ? ball.owner.role : "Loose"} | Wetter: ${weather.type}`, canvas.width);
   drawGoalHighlight(ctx, goalOverlayText, goalOverlayTimer, canvas.width, canvas.height);
   drawRadar(radarCtx, allPlayers, ball, radarCanvas.width, radarCanvas.height);
+  if (matchPaused) {
+    drawOverlay(ctx, 'Spiel beendet', canvas.width);
+  }
 
   // 8. Score/Goal Check/Timer
   checkGoal(ball);


### PR DESCRIPTION
## Summary
- add `reset` to input handler so pressing `R` restarts the match
- show keyboard hint on the demo page
- display match end overlay and restart the match when `R` is pressed

## Testing
- `npm run build`
- `node test/formation.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_686944bda2508326a1d064a5c64be36b