### PR TITLE
Implement simple referee rule system

### DIFF
--- a/demo/soccer/capabilities.js
+++ b/demo/soccer/capabilities.js
@@ -31,6 +31,7 @@ export const Capabilities = {
     const startY = player.y + (dy / dist) * offset;
     ball.kick(startX, startY, dx, dy, 12, spin, player);
     player.currentAction = 'pass';
+    if (world.referee) world.referee.handlePass(player, target, world.players);
   },
 
   lobPass(player, world, target) {
@@ -48,11 +49,13 @@ export const Capabilities = {
     ball.kick(startX, startY, dx, dy, 10, spin, player);
     ball.vy -= 2; // simple lift
     player.currentAction = 'lobPass';
+    if (world.referee) world.referee.handlePass(player, target, world.players);
   },
 
   cross(player, world, targetArea) {
     this.lobPass(player, world, targetArea || world.opponentGoal);
     player.currentAction = 'cross';
+    if (world.referee) world.referee.handlePass(player, targetArea, world.players);
   },
 
  dribble(player, world, direction) {
@@ -91,11 +94,13 @@ export const Capabilities = {
     if (!mate) return;
     this.pass(player, world, mate);
     mate.sendMessage(player, { type: 'oneTwoReturn' });
+    if (world.referee) world.referee.handlePass(player, mate, world.players);
   },
 
   backPass(player, world, target) {
     this.pass(player, world, target);
     player.currentAction = 'backPass';
+    if (world.referee) world.referee.handlePass(player, target, world.players);
   },
 
   // Off-the-ball actions

--- a/demo/soccer/referee.js
+++ b/demo/soccer/referee.js
@@ -1,9 +1,11 @@
 import { logComment } from './commentary.js';
+import { isOffside, restartTypeForOut } from './rules.js';
 
 export class Referee {
-  constructor(onCardCallback, onFoulCallback) {
+  constructor(onCardCallback, onFoulCallback, onOffsideCallback) {
     this.onCard = onCardCallback;
     this.onFoul = onFoulCallback;
+    this.onOffside = onOffsideCallback;
   }
 
   update(players, ball) {
@@ -20,6 +22,16 @@ export class Referee {
         }
       }
     }
+  }
+
+  handlePass(passer, receiver, players) {
+    if (isOffside(passer, receiver, players) && this.onOffside) {
+      this.onOffside(receiver);
+    }
+  }
+
+  checkRestart(ball, lastTouchTeam) {
+    return restartTypeForOut(ball, lastTouchTeam);
   }
 
   callFoul(player, victim) {

--- a/demo/soccer/rules.js
+++ b/demo/soccer/rules.js
@@ -1,0 +1,29 @@
+export function secondLastDefenderX(players, attackingSide) {
+  const defenders = players.filter(p => p.side !== attackingSide);
+  const xs = defenders.map(p => p.x).sort((a, b) => a - b);
+  if (xs.length < 2) {
+    return attackingSide === 'home' ? 1035 : 15;
+  }
+  return attackingSide === 'home' ? xs[xs.length - 2] : xs[1];
+}
+
+export function isOffside(passer, receiver, players) {
+  if (!receiver || receiver.side !== passer.side) return false;
+  const line = secondLastDefenderX(players, passer.side);
+  if (passer.side === 'home') {
+    return receiver.x > line && receiver.x > passer.x && receiver.x > 525;
+  }
+  return receiver.x < line && receiver.x < passer.x && receiver.x < 525;
+}
+
+export function restartTypeForOut(ball, lastTouchTeam) {
+  if (!ball.outOfBounds) return null;
+  if (ball.outOfBounds === 'top' || ball.outOfBounds === 'bottom') {
+    return { type: 'throwIn', side: ball.outOfBounds };
+  }
+  const side = ball.outOfBounds;
+  if (lastTouchTeam === (side === 'left' ? 0 : 1)) {
+    return { type: 'corner', side };
+  }
+  return { type: 'goalKick', side };
+}


### PR DESCRIPTION
## Summary
- add `rules.js` with offside and restart helpers
- extend `Referee` to evaluate offsides and restarts
- invoke referee from player capabilities and pass handling
- provide offside callback and use it in game logic
- centralize out-of-bounds restarts through referee

## Testing
- `npm run build`
- `node test/formation.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_686981851f0c8326aec13423b2d2b68b