### PR TITLE
Add soccer penalties and simple 3D multiplayer

### DIFF
--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -590,14 +590,23 @@ function handleCard(player, card) {
   playWhistle();
 }
 
-function handleFoul(fouler, victim) {
-  freeKickTimer = 2;
-  freeKickTaker = victim;
-  ball.owner = victim;
-  ball.isLoose = false;
+function handleFoul(fouler, victim, restart) {
+  if (restart && restart.type === "penalty") {
+    restartTimer = 2;
+    restartType = "Elfmeter";
+    ball.owner = victim;
+    ball.isLoose = false;
+    ball.x = victim.side === "home" ? 165 : 885;
+    ball.y = 340;
+  } else {
+    freeKickTimer = 2;
+    freeKickTaker = victim;
+    ball.owner = victim;
+    ball.isLoose = false;
+    ball.x = victim.x;
+    ball.y = victim.y;
+  }
   setLastTouch(victim);
-  ball.x = victim.x;
-  ball.y = victim.y;
   logComment(`Foul an ${victim.role}`);
   playWhistle();
 }

--- a/demo/soccer/main3d.js
+++ b/demo/soccer/main3d.js
@@ -1,6 +1,7 @@
 import * as THREE from 'https://unpkg.com/three@0.156.1/build/three.module.js';
 import { Player3D } from './player3d.js';
 import { Ball3D } from './ball3d.js';
+import { initMultiplayer } from './multiplayer.js';
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -46,6 +47,8 @@ players.forEach(p => { p.addTo(scene); });
 const ball = new Ball3D(0, 0, 0.11);
 ball.addTo(scene);
 
+const mp = initMultiplayer(players[0], players[1], ball) || { sendState: () => {}, sendKick: () => {} };
+
 function updateCamera(snap = false) {
   const target = ball.position.clone().add(cameraOffset);
   if (snap) {
@@ -80,8 +83,10 @@ function updatePlayerControls(dt) {
     const dir = ball.position.clone().sub(p.position);
     if (dir.length() < 1.5) {
       ball.kick(dir, 5);
+      mp.sendKick(dir.x, dir.y, 5);
     }
   }
+  mp.sendState();
 }
 
 

--- a/demo/soccer/multiplayer.js
+++ b/demo/soccer/multiplayer.js
@@ -1,0 +1,43 @@
+export function initMultiplayer(localPlayer, remotePlayer, ball, url = 'ws://localhost:8080') {
+  let socket;
+  try {
+    socket = new WebSocket(url);
+  } catch (e) {
+    console.warn('Multiplayer unavailable:', e);
+    return null;
+  }
+
+  socket.addEventListener('message', (e) => {
+    try {
+      const data = JSON.parse(e.data);
+      if (data.t === 'state') {
+        remotePlayer.position.x = data.x;
+        remotePlayer.position.y = data.y;
+      } else if (data.t === 'kick') {
+        const dir = { x: data.dx, y: data.dy };
+        if (ball.kick) {
+          ball.kick(dir, data.p);
+        }
+      }
+    } catch {}
+  });
+
+  function sendState() {
+    if (socket.readyState === WebSocket.OPEN) {
+      const msg = {
+        t: 'state',
+        x: localPlayer.position.x,
+        y: localPlayer.position.y,
+      };
+      socket.send(JSON.stringify(msg));
+    }
+  }
+
+  function sendKick(dx, dy, power = 5) {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ t: 'kick', dx, dy, p: power }));
+    }
+  }
+
+  return { socket, sendState, sendKick };
+}

--- a/demo/soccer/referee.js
+++ b/demo/soccer/referee.js
@@ -1,5 +1,5 @@
 import { logComment } from './commentary.js';
-import { isOffside, restartTypeForOut } from './rules.js';
+import { isOffside, restartTypeForOut, restartTypeForFoul } from './rules.js';
 
 export class Referee {
   constructor(onCardCallback, onFoulCallback, onOffsideCallback) {
@@ -45,7 +45,8 @@ export class Referee {
     }
     victim.highlightTimer = 1;
     if (this.onFoul) {
-      this.onFoul(player, victim);
+      const restart = restartTypeForFoul(victim, player);
+      this.onFoul(player, victim, restart);
     }
   }
 }

--- a/demo/soccer/rules.js
+++ b/demo/soccer/rules.js
@@ -27,3 +27,21 @@ export function restartTypeForOut(ball, lastTouchTeam) {
   }
   return { type: 'goalKick', side };
 }
+
+export const PENALTY_BOX = {
+  home: { x1: 15, x2: 165, y1: 215, y2: 465 },
+  away: { x1: 885, x2: 1035, y1: 215, y2: 465 },
+};
+
+export function inPenaltyBox(x, y, defendingSide) {
+  const box = defendingSide === 'home' ? PENALTY_BOX.home : PENALTY_BOX.away;
+  return x >= box.x1 && x <= box.x2 && y >= box.y1 && y <= box.y2;
+}
+
+export function restartTypeForFoul(victim, fouler) {
+  const defendingSide = victim.side;
+  if (inPenaltyBox(victim.x, victim.y, defendingSide)) {
+    return { type: 'penalty', side: defendingSide };
+  }
+  return { type: 'freeKick', side: defendingSide };
+}

--- a/demo/soccer/server.js
+++ b/demo/soccer/server.js
@@ -1,0 +1,18 @@
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 8080 });
+const clients = new Set();
+
+wss.on('connection', (ws) => {
+  clients.add(ws);
+  ws.on('message', (msg) => {
+    for (const c of clients) {
+      if (c !== ws && c.readyState === ws.OPEN) {
+        c.send(msg);
+      }
+    }
+  });
+  ws.on('close', () => clients.delete(ws));
+});
+
+console.log('Multiplayer server running on ws://localhost:8080');

--- a/test/rules.test.cjs
+++ b/test/rules.test.cjs
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const { inPenaltyBox, restartTypeForFoul, PENALTY_BOX } = require('../demo/soccer/rules.js');
+
+assert(inPenaltyBox(PENALTY_BOX.home.x1 + 10, 340, 'home'));
+assert(!inPenaltyBox(PENALTY_BOX.home.x2 + 10, 340, 'home'));
+
+const victim = { x: 20, y: 340, side: 'home' };
+const fouler = { x: 25, y: 340, side: 'away' };
+const restart = restartTypeForFoul(victim, fouler);
+assert.equal(restart.type, 'penalty');
+assert.equal(restart.side, 'home');
+
+console.log('rules tests passed');


### PR DESCRIPTION
## Summary
- extend soccer rules with penalty logic
- surface restart type for fouls in referee logic
- handle penalty kicks in the main game loop
- add minimal WebSocket-based multiplayer module and demo server
- sync player actions in 3D mode
- test new rules helpers

## Testing
- `npm run build`
- `node test/formation.test.cjs && node test/rules.test.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68698eba34408326bfede98d7ae7c742