### PR TITLE
Implement basic debug overlay

### DIFF
--- a/demo/soccer/debugManager.js
+++ b/demo/soccer/debugManager.js
@@ -1,0 +1,46 @@
+import { drawZones, drawIntents } from './render.js';
+
+export class DebugManager {
+  constructor(ctx, infoEl) {
+    this.ctx = ctx;
+    this.infoEl = infoEl;
+    this.showZones = true;
+    this.showIntents = false;
+    this.showInspector = false;
+    this.selectedPlayer = null;
+    window.addEventListener('keydown', e => this.onKey(e));
+  }
+
+  onKey(e) {
+    if (e.code === 'KeyZ') this.showZones = !this.showZones;
+    else if (e.code === 'KeyI') this.showIntents = !this.showIntents;
+    else if (e.code === 'KeyM') this.showInspector = !this.showInspector;
+  }
+
+  setSelectedPlayer(p) {
+    this.selectedPlayer = p;
+    if (!p && this.infoEl) this.infoEl.style.display = 'none';
+  }
+
+  draw(world) {
+    const ctx = this.ctx;
+    if (!ctx) return;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    if (this.showZones) drawZones(ctx, world.players, { ball: world.ball, tactic: world.tactic });
+    if (this.showIntents) drawIntents(ctx, world.players);
+    if (this.showInspector && this.selectedPlayer) this.drawInspector(this.selectedPlayer);
+  }
+
+  drawInspector(player) {
+    if (!this.infoEl) return;
+    this.infoEl.style.display = 'block';
+    this.infoEl.style.left = `${player.x + 15}px`;
+    this.infoEl.style.top = `${player.y - 10}px`;
+    const speed = Math.hypot(player.vx, player.vy).toFixed(2);
+    const energy = Math.round((player.stamina ?? 1) * 100);
+    this.infoEl.innerHTML = `<strong>#${player.role}</strong><br>` +
+      `intent: ${player.currentAction || 'none'}<br>` +
+      `speed: ${speed}<br>` +
+      `energy: ${energy}%`;
+  }
+}

--- a/demo/soccer/index.html
+++ b/demo/soccer/index.html
@@ -120,7 +120,11 @@
     <canvas id="radar" width="210" height="136"></canvas>
     <div id="powerBarWrapper"><div id="powerBar"></div></div>
     <p style="text-align:center;margin-top:4px;">Spieler anklicken und mit Pfeiltasten oder Gamepad steuern &ndash; 'R' setzt das Spiel zurück</p>
-    <canvas id="spielfeld" width="1050" height="680"></canvas>
+    <div style="position:relative;width:1050px;margin:0 auto;">
+      <canvas id="spielfeld" width="1050" height="680"></canvas>
+      <canvas id="debugCanvas" width="1050" height="680" style="position:absolute;top:0;left:0;pointer-events:none;"></canvas>
+      <div id="inspector" style="position:absolute;pointer-events:none;color:#fff;background:#000a;padding:4px;font-size:12px;display:none;"></div>
+    </div>
     <div id="commentary"></div>
     <script type="module" src="main.js"></script>
 </body>

--- a/demo/soccer/main.js
+++ b/demo/soccer/main.js
@@ -4,6 +4,7 @@ import { Player } from "./player.js";
 import { Coach } from "./coach.js";
 import { Ball, FIELD_BOUNDS } from "./ball.js";
 import { drawField, drawPlayers, drawBall, drawOverlay, drawPasses, drawPerceptionHighlights, drawPassIndicator, drawRadar, drawActivePlayer, drawGoalHighlight, drawZones, drawBallDebug, drawFormationDebug } from "./render.js";
+import { DebugManager } from "./debugManager.js";
 import { logComment } from "./commentary.js";
 import { initControlPanel } from "./ui-panel.js";
 import { Referee } from "./referee.js";
@@ -14,6 +15,9 @@ import { analyzePlayerPerformance, evaluateFootUse } from "./analyze.js";
 // ----- Game Setup -----
 const canvas = document.getElementById("spielfeld");
 const ctx = canvas.getContext("2d");
+const debugCanvas = document.getElementById("debugCanvas");
+const debugCtx = debugCanvas.getContext("2d");
+const inspectorDiv = document.getElementById("inspector");
 const powerBarWrapper = document.getElementById("powerBarWrapper");
 const powerBar = document.getElementById("powerBar");
 const radarCanvas = document.getElementById("radar");
@@ -34,6 +38,7 @@ window.keyBindings = {
 };
 const inputHandler = new InputHandler();
 window.debugOptions = { showZones: true, showFOV: true, showBall: true, showFormation: false };
+const debugManager = new DebugManager(debugCtx, inspectorDiv);
 
 window.colorProfiles = {
   default: { field: "#065", home: "#0000ff", away: "#ff0000", background: "#222" },
@@ -683,6 +688,7 @@ applyWeather();
 applyColorProfile(window.renderOptions.colorProfile);
 initControlPanel({ teams: { home: teamHeim, away: teamGast }, ball, coach, formations });
 selectedPlayer = teamHeim[0];
+debugManager.setSelectedPlayer(selectedPlayer);
 userTeam = teamHeim;
 selectedPlayer2 = teamGast[0];
 userTeam2 = teamGast;
@@ -700,6 +706,7 @@ canvas.addEventListener("click", (e) => {
       } else {
         selectedPlayer2 = p;
       }
+      debugManager.setSelectedPlayer(p);
       break;
     }
   }
@@ -1313,6 +1320,7 @@ function gameLoop(timestamp) {
   drawOverlay(ctx, `Ball: ${ball.owner ? ball.owner.role : "Loose"} | Wetter: ${weather.type}`, canvas.width);
   drawGoalHighlight(ctx, goalOverlayText, goalOverlayTimer, canvas.width, canvas.height);
   drawRadar(radarCtx, allPlayers, ball, radarCanvas.width, radarCanvas.height);
+  debugManager.draw({ players: allPlayers, ball, tactic: coach?.pressing > 1 ? "pressing" : null });
   if (matchPaused) {
     drawOverlay(ctx, "Spiel beendet", canvas.width);
   

--- a/demo/soccer/render.js
+++ b/demo/soccer/render.js
@@ -225,6 +225,25 @@ export function drawZones(ctx, players, world, offsets = { home: {x:0,y:0}, away
   ctx.restore();
 }
 
+export function drawIntents(ctx, players) {
+  if (!players) return;
+  ctx.save();
+  ctx.strokeStyle = 'yellow';
+  ctx.fillStyle = 'yellow';
+  ctx.lineWidth = 1;
+  ctx.font = '11px Arial';
+  players.forEach(p => {
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(p.targetX, p.targetY);
+    ctx.stroke();
+    if (p.currentAction) {
+      ctx.fillText(p.currentAction, p.x + 6, p.y - 6);
+    }
+  });
+  ctx.restore();
+}
+
 export function drawSoftZones(ctx, players, ball, coach, options = {}) {
   const { heatmap = false } = options;
   ctx.save();


### PR DESCRIPTION
## Summary
- add `DebugManager` module to centralize debug visuals and toggles
- render player intents with a new `drawIntents` function
- extend HTML to host an overlay canvas and inspector panel
- initialize and invoke the overlay from the main game loop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869a0997030832693c91de4385cc847