### PR TITLE
Add debug visualization subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,20 @@ connection also shows a label indicating which property values are linked. You
 can double‑click on a connection itself to add hidden anchor points that shape
 the line without altering its curve. Right‑click a card to open a small context
 menu with options to remove the card or clear all of its connections.
+
+## Debug Visualization
+
+A small debugging subsystem is included under `src/debug/`. Use the following keys at runtime to toggle overlays:
+
+- **Z** – toggle zone visualization
+- **F** – toggle field of view
+- **R** – toggle radar
+- **I** – toggle player intents
+- **B** – toggle ball debug info
+- **D** – toggle dribble side markers
+
+Messages can be written to the on page console using `logDebug()` from `src/debug/logger.js`. The console element is added at the bottom of `public/index.html` and automatically scrolls to the newest entry.
+
+To show state information each frame, call `renderDebugLayers()` from `src/render.js` inside your main loop. You can optionally draw a HUD with `drawDebugOverlay()`.
+
+New debug drawing functions can be integrated by extending `renderDebugLayers()` and providing implementations alongside the existing placeholder functions in `src/render.js`.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Debug Demo</title>
+</head>
+<body>
+  <canvas id="main" width="640" height="480"></canvas>
+  <script type="module">
+    import './src/debug/hotkeys.js';
+    import { logDebug } from './src/debug/logger.js';
+    logDebug('Debug system initialized');
+  </script>
+  <div id="game-debug-console" style="
+  position: fixed; bottom: 0; left: 0; width: 100%; height: 120px;
+  background: #000; color: #0f0; overflow-y: auto;
+  font: 12px monospace; padding: 4px; z-index: 9999;">
+  </div>
+</body>
+</html>

--- a/src/debug/debugOptions.js
+++ b/src/debug/debugOptions.js
@@ -1,0 +1,15 @@
+export const debugOptions = {
+  showRunDir: true,
+  showHeadDir: false,
+  showFOV: false,
+  showZones: true,
+  showSoftZones: false,
+  showIntents: false,
+  showFormationDebug: false,
+  showBallDebug: false,
+  showPasses: false,
+  showDribbleSide: false,
+  showPerception: false,
+  showRadar: true,
+  showDebugOverlay: true,
+};

--- a/src/debug/hotkeys.js
+++ b/src/debug/hotkeys.js
@@ -1,0 +1,26 @@
+import { debugOptions } from './debugOptions.js';
+
+window.addEventListener('keydown', e => {
+  switch (e.key.toLowerCase()) {
+    case 'z':
+      debugOptions.showZones = !debugOptions.showZones;
+      break;
+    case 'f':
+      debugOptions.showFOV = !debugOptions.showFOV;
+      break;
+    case 'r':
+      debugOptions.showRadar = !debugOptions.showRadar;
+      break;
+    case 'i':
+      debugOptions.showIntents = !debugOptions.showIntents;
+      break;
+    case 'b':
+      debugOptions.showBallDebug = !debugOptions.showBallDebug;
+      break;
+    case 'd':
+      debugOptions.showDribbleSide = !debugOptions.showDribbleSide;
+      break;
+    // Weitere Tasten nach Bedarf
+  }
+  console.log('Toggled debug:', debugOptions);
+});

--- a/src/debug/logger.js
+++ b/src/debug/logger.js
@@ -1,0 +1,7 @@
+export function logDebug(message) {
+  const div = document.getElementById('game-debug-console');
+  if (!div) return;
+  const time = new Date().toISOString().slice(11, 19);
+  div.innerHTML += `[${time}] ${message}<br>`;
+  div.scrollTop = div.scrollHeight;
+}

--- a/src/render.js
+++ b/src/render.js
@@ -1,0 +1,37 @@
+import { debugOptions } from './debug/debugOptions.js';
+
+// Placeholder drawing functions; actual implementations should exist elsewhere
+export function drawPlayers(ctx, players, opts = {}) {}
+export function drawBall(ctx, ball) {}
+export function drawRadar(ctx, players, ball, w, h) {}
+export function drawZones(ctx, players, world) {}
+export function drawSoftZones(ctx, players, ball, coach) {}
+export function drawIntents(ctx, players) {}
+export function drawFormationDebug(ctx, players) {}
+export function drawPerceptionHighlights(ctx, player) {}
+export function drawPasses(ctx, players, ball) {}
+export function drawBallDebug(ctx, ball) {}
+export function drawDribbleSide(ctx, player) {}
+
+export function renderDebugLayers(ctx, state) {
+  const { players, ball, world, coach, activePlayer } = state;
+
+  if (debugOptions.showRadar) drawRadar(ctx.radar, players, ball, 120, 80);
+  if (debugOptions.showZones) drawZones(ctx.main, players, world);
+  if (debugOptions.showSoftZones) drawSoftZones(ctx.main, players, ball, coach);
+  if (debugOptions.showIntents) drawIntents(ctx.main, players);
+  if (debugOptions.showFormationDebug) drawFormationDebug(ctx.main, players);
+  if (debugOptions.showBallDebug) drawBallDebug(ctx.main, ball);
+  if (debugOptions.showDribbleSide) players.forEach(p => drawDribbleSide(ctx.main, p));
+  if (debugOptions.showPerception && activePlayer) drawPerceptionHighlights(ctx.main, activePlayer);
+  if (debugOptions.showPasses) drawPasses(ctx.main, players, ball);
+}
+
+export function drawDebugOverlay(ctx, state, width) {
+  const { fps, players, ball } = state;
+  ctx.fillStyle = 'rgba(0,0,0,0.8)';
+  ctx.fillRect(0, 0, width, 32);
+  ctx.fillStyle = 'white';
+  ctx.font = '14px monospace';
+  ctx.fillText(`FPS: ${fps} | Ball Speed: ${ball.vx.toFixed(1)},${ball.vy.toFixed(1)} | Players: ${players.length}`, 10, 20);
+}


### PR DESCRIPTION
## Summary
- add central debugOptions and hotkey toggles
- provide DOM logger element and helper
- create render helpers for debug layers
- wire demo HTML to load the debug scripts
- document usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a709911ec832696c9e91ea5c24649